### PR TITLE
fix 🐛: attributedBody text extraction for smart quotes and short messages

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -508,7 +508,7 @@ export class IMessageDatabase {
                     .filter((match) => {
                         if (excludedPatterns.test(match)) return false
                         if (/^[\[\(\)\]\*,\-:X]+$/.test(match)) return false
-                        if (/NS\.\w+/.test(match)) return false
+                        if (/^NS\.\w+/.test(match)) return false
                         if (/__kIM/.test(match)) return false
                         if (/\$version|\$archiver|\$top|\$objects|\$class/.test(match)) return false
                         return match.length >= 1
@@ -529,7 +529,7 @@ export class IMessageDatabase {
                         .replace(/^\+\+./, '') // Remove ++ prefix (plist marker like ++3)
                         .replace(/^\+[\*@#!]/, '') // Remove +* +@ +# +! prefix
                         .replace(/^\+(\d)(?=[^\d\s])/, '') // Remove +N only if followed by non-digit non-space (e.g., +3hello → hello)
-                        .replace(/\[PhoneNumber.*$/, '') // Remove trailing plist artifacts
+                        .replace(/\[PhoneNumber\s+.*\]$/, '') // Remove trailing plist artifacts
                         .replace(/"$/, '')
                         .trim()
                 }


### PR DESCRIPTION
## Problem

`attributedBody` text extraction had three issues that caused messages to be lost or corrupted:

1. **Smart quotes broke text**
   - `abc’xyz` (U+2019) was split and truncated → only `xyz` kept.
   - Root cause: readable‑char regex didn’t include smart quote / other Unicode punctuation.

2. **Short messages returned `null`**
   - Messages shorter than 5 chars (`"test"`, `"hi"`, `"ok"`) were filtered out.
   - Root cause: `{5,}` in the regex + `length > 5` post‑filter.

3. **Binary prefixes leaked into text**
   - Typedstream length markers like `+3`, `++3`, `+*` appeared at the start of messages.
   - Example: `+3hello world` instead of `hello world`.

---

## Solution

1. **Prefer `plutil` for decoding**
   - Use `plutil -convert xml1` to turn `attributedBody` into XML and extract `<string>` values.
   - Only fall back to buffer + regex when `plutil` fails.

2. **Improve fallback extraction**
   - Expand readable‑char regex to include smart quotes, ellipsis, dashes, and CJK (Chinese/Japanese/Korean).
   - Remove hard minimum length; rely on a scoring heuristic instead of `{5,}` and `length > 5`.
   - Make prefix cleanup precise:
     - Strip `++N`, `+*`, `+@`, `+#`, and `+N` when followed by a non‑digit, non‑space.
     - Keep valid user content like `+1234567890`, `+1 idea`, `+100 points`.

---

Fix ENG-304