### PR TITLE
Release v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@photon-ai/imessage-kit",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@photon-ai/imessage-kit",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "license": "MIT",
             "os": [
                 "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@photon-ai/imessage-kit",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "A type-safe, elegant iMessage SDK for macOS with zero dependencies",
     "author": "GreatSomething",
     "license": "MIT",


### PR DESCRIPTION
## v2.0.1

### Summary

Bug fix release for attributedBody text extraction and license update.

### Changes

**Bug Fixes**
- Fix `extractTextFromAttributedBody` failing on smart quotes and short messages
- Improve regex patterns to be stricter, avoiding false matches on plist markers
- Prioritize plutil parsing over direct buffer extraction for cleaner text output
- Support single-character messages (minimum length reduced from 5 to 1)