### PR TITLE
Preserve attachment extension in temp files (fixes photon-hq/imessage…

### DIFF
--- a/__tests__/13-security-injection.test.ts
+++ b/__tests__/13-security-injection.test.ts
@@ -208,6 +208,32 @@ describe('Security: AppleScript Injection Prevention', () => {
             expect(script).toContain('.jpg')
             expect(script).not.toContain('bad"name')
         })
+
+        test('should replace X characters in filename to avoid mktemp confusion', () => {
+            const { script } = generateSendAttachmentScript('user', '/tmp/fileXXXname.png')
+            // X characters should be replaced with _ in the mktemp template
+            expect(script).toMatch(/imsg_temp_file___name_XXXXXXXXXX\.png/)
+        })
+
+        test('should handle compound extensions (only last extension preserved)', () => {
+            const { script } = generateSendAttachmentScript('user', '/tmp/archive.tar.gz')
+            // extname only returns .gz, .tar becomes part of basename
+            expect(script).toMatch(/imsg_temp_archive\.tar_XXXXXXXXXX\.gz/)
+        })
+
+        test('should handle dotfiles (basename starts with dot)', () => {
+            const { script } = generateSendAttachmentScript('user', '/tmp/.hidden')
+            // For .hidden, basename is ".hidden" and ext is empty, dot is allowed
+            expect(script).toMatch(/imsg_temp_\.hidden_XXXXXXXXXX/)
+        })
+
+        test('should truncate excessively long filenames in template', () => {
+            const longName = 'a'.repeat(100)
+            const { script } = generateSendAttachmentScript('user', `/tmp/${longName}.jpg`)
+            // Basename should be truncated to 60 chars in mktemp template
+            const truncatedName = 'a'.repeat(60)
+            expect(script).toMatch(new RegExp(`imsg_temp_${truncatedName}_XXXXXXXXXX\\.jpg`))
+        })
     })
 
     // ------------------------------------------------------------

--- a/src/utils/applescript.ts
+++ b/src/utils/applescript.ts
@@ -222,7 +222,25 @@ function needsSandboxBypass(filePath: string): boolean {
 }
 
 /**
- * Build a mktemp template that preserves file extension for better UX in Messages
+ * Build a `mktemp`-compatible filename template that preserves the original file
+ * extension for better UX in Messages.
+ *
+ * Sanitization rules and rationale:
+ * - Special characters in the basename are replaced with underscores (`_`)
+ *   to produce a shell-safe template and avoid issues when passed to `mktemp`.
+ * - Literal `X` characters in the basename are replaced with underscores to
+ *   avoid confusion with `mktemp`'s own `X` pattern, which it interprets as
+ *   a placeholder for random characters.
+ * - The sanitized basename is truncated to 60 characters to keep the final
+ *   path length within reasonable limits.
+ *
+ * The final template has the form:
+ *   `imsg_temp_{basename}_XXXXXXXXXX{ext}`
+ * where:
+ * - `{basename}` is the sanitized, at-most-60-character basename (or omitted
+ *   entirely if empty, in which case the underscore is also omitted), and
+ * - `{ext}` is the sanitized file extension (non-alphanumeric characters are
+ *   stripped).
  */
 function buildTempFilenameTemplate(filePath: string): string {
     const ext = extname(filePath)


### PR DESCRIPTION
this fix got sending images to work for me:

<img width="388" height="350" alt="Screenshot 2026-01-12 at 9 27 36 AM" src="https://github.com/user-attachments/assets/15356784-e09d-4a7c-8879-9ea434b44bb7" />

Fix ENG-693