### PR TITLE
fix 🐛: remove os restriction to allow installation on non-macOS for type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,9 +69,6 @@
     "engines": {
         "node": ">=18.0.0"
     },
-    "os": [
-        "darwin"
-    ],
     "sideEffects": false,
     "dependencies": {
         "node-typedstream": "^1.4.1"


### PR DESCRIPTION
## Description

This PR removes the `"os": ["darwin"]` restriction from `package.json` to enable cross-platform installation for development purposes.

### Problem

When users install `@photon-ai/imessage-kit` in GitHub CI or other Linux-based environments, npm/yarn/pnpm silently skips the package installation due to the OS restriction. This prevents:
- Type checking in CI pipelines
- Build processes that import the package
- Any development workflow on non-macOS machines

### Solution

Remove the `os` field from `package.json`. The package can now be installed on any platform, enabling:
- Type checking (`tsc --noEmit`) in CI
- Build and lint workflows on Linux runners
- Development on any OS (types/intellisense work everywhere)

Runtime functionality (AppleScript automation, iMessage database access) still requires macOS and will fail gracefully with appropriate errors when invoked on unsupported platforms.

### Changes

- Removed `"os": ["darwin"]` from `package.json`

### Testing

- Verified package installs successfully on Linux
- Type checking passes on non-macOS environments

Fix ENG-750