### PR TITLE
fix: support modern macOS group chat ID format (any;+;) and add watcher checkpoint

### DIFF
--- a/.codegraph.agent.txt
+++ b/.codegraph.agent.txt
@@ -1,0 +1,57 @@
+╔════════════════════════════════════════════════════════════╗
+║                    CODEGRAPH SUMMARY                       ║
+╚════════════════════════════════════════════════════════════╝
+
+METRICS:
+  Total nodes:              269
+  Total edges:              554
+  Total functions:          181
+  Avg impact score:         4
+  Max impact score:         65
+  Cross-service links:      0
+
+NODES BY TYPE:
+  module: 60
+  kafka-producer: 13
+  function: 181
+  class: 15
+
+HIGH IMPACT FUNCTIONS (most dependents):
+  loggerPlugin.log
+    Impact: 65 transitive, 35 direct callers
+    Location: src/plugins/logger.ts:87
+  escapeAppleScriptString
+    Impact: 33 transitive, 10 direct callers
+    Location: src/utils/applescript.ts:166
+  MessagePromise.resolve
+    Impact: 28 transitive, 7 direct callers
+    Location: src/core/message-promise.ts:107
+  calculateFileDelay
+    Impact: 25 transitive, 4 direct callers
+    Location: src/utils/applescript.ts:262
+  SendError
+    Impact: 22 transitive, 8 direct callers
+    Location: src/core/errors.ts:38
+  MessageScheduler.get
+    Impact: 20 transitive, 4 direct callers
+    Location: src/utils/scheduler.ts:342
+  buildTempFilenameTemplate
+    Impact: 19 transitive, 2 direct callers
+    Location: src/utils/applescript.ts:246
+  needsSandboxBypass
+    Impact: 17 transitive, 4 direct callers
+    Location: src/utils/applescript.ts:221
+  delay
+    Impact: 17 transitive, 4 direct callers
+    Location: src/utils/common.ts:9
+  generateSecureFilename
+    Impact: 17 transitive, 3 direct callers
+    Location: src/utils/download.ts:20
+
+⚠ LOW TYPE COVERAGE (<50%):
+  str: 33%
+  num: 33%
+  PlatformError: 33%
+
+────────────────────────────────────────────────────────────
+Estimated tokens: ~410

--- a/.codegraph.json
+++ b/.codegraph.json
@@ -1,0 +1,9289 @@
+{
+  "schema": "codegraph/v1",
+  "timestamp": "2026-03-06T23:55:16.218Z",
+  "rootPath": ".",
+  "nodes": [
+    {
+      "id": "module:demo:demo.ts",
+      "type": "module",
+      "name": "demo",
+      "metadata": {
+        "filePath": "demo.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:tsup.config:tsup.config.ts",
+      "type": "module",
+      "name": "tsup.config",
+      "metadata": {
+        "filePath": "tsup.config.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:01-errors.test:__tests__/01-errors.test.ts",
+      "type": "module",
+      "name": "01-errors.test",
+      "metadata": {
+        "filePath": "__tests__/01-errors.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:02-utils.test:__tests__/02-utils.test.ts",
+      "type": "module",
+      "name": "02-utils.test",
+      "metadata": {
+        "filePath": "__tests__/02-utils.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:03-database.test:__tests__/03-database.test.ts",
+      "type": "module",
+      "name": "03-database.test",
+      "metadata": {
+        "filePath": "__tests__/03-database.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:04-plugins.test:__tests__/04-plugins.test.ts",
+      "type": "module",
+      "name": "04-plugins.test",
+      "metadata": {
+        "filePath": "__tests__/04-plugins.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:05-chain.test:__tests__/05-chain.test.ts",
+      "type": "module",
+      "name": "05-chain.test",
+      "metadata": {
+        "filePath": "__tests__/05-chain.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:06-sdk-core.test:__tests__/06-sdk-core.test.ts",
+      "type": "module",
+      "name": "06-sdk-core.test",
+      "metadata": {
+        "filePath": "__tests__/06-sdk-core.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "kafka-producer:_1234567890:__tests__/06-sdk-core.test.ts",
+      "type": "kafka-producer",
+      "name": "Producer: +1234567890",
+      "metadata": {
+        "filePath": "__tests__/06-sdk-core.test.ts",
+        "lineNumber": 423,
+        "kafkaTopic": "+1234567890"
+      }
+    },
+    {
+      "id": "module:07-integration.test:__tests__/07-integration.test.ts",
+      "type": "module",
+      "name": "07-integration.test",
+      "metadata": {
+        "filePath": "__tests__/07-integration.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:08-listchats.test:__tests__/08-listchats.test.ts",
+      "type": "module",
+      "name": "08-listchats.test",
+      "metadata": {
+        "filePath": "__tests__/08-listchats.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:09-search-and-attachments.test:__tests__/09-search-and-attachments.test.ts",
+      "type": "module",
+      "name": "09-search-and-attachments.test",
+      "metadata": {
+        "filePath": "__tests__/09-search-and-attachments.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:10-message-promise.test:__tests__/10-message-promise.test.ts",
+      "type": "module",
+      "name": "10-message-promise.test",
+      "metadata": {
+        "filePath": "__tests__/10-message-promise.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:11-outgoing-manager.test:__tests__/11-outgoing-manager.test.ts",
+      "type": "module",
+      "name": "11-outgoing-manager.test",
+      "metadata": {
+        "filePath": "__tests__/11-outgoing-manager.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:12-attributed-body.test:__tests__/12-attributed-body.test.ts",
+      "type": "module",
+      "name": "12-attributed-body.test",
+      "metadata": {
+        "filePath": "__tests__/12-attributed-body.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:extractTextFromAttributedBody:__tests__/12-attributed-body.test.ts",
+      "type": "function",
+      "name": "extractTextFromAttributedBody",
+      "metadata": {
+        "filePath": "__tests__/12-attributed-body.test.ts",
+        "lineNumber": 13,
+        "endLineNumber": 52,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "attributedBody"
+        ],
+        "parameterTypes": [
+          "unknown"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [
+          "attributedBody"
+        ],
+        "typeCoveragePercent": 50,
+        "contentHash": "654c909e89e1ae2c",
+        "signatureHash": "8c691a4386bb72cb"
+      }
+    },
+    {
+      "id": "module:12-scheduler.test:__tests__/12-scheduler.test.ts",
+      "type": "module",
+      "name": "12-scheduler.test",
+      "metadata": {
+        "filePath": "__tests__/12-scheduler.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:createMockSDK:__tests__/12-scheduler.test.ts",
+      "type": "function",
+      "name": "createMockSDK",
+      "metadata": {
+        "filePath": "__tests__/12-scheduler.test.ts",
+        "lineNumber": 21,
+        "endLineNumber": 31,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "sendImpl"
+        ],
+        "parameterTypes": [
+          "(to: string, content: any) => Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>"
+        ],
+        "returnType": "{ sdk: import(\"/Users/mason/Documents/imessage-kit/src/core/sdk\").IMessageSDK; sendSpy: { fn: (to: string, content: any) => Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>; calls: { args: [to: string, content: any]; result?: Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>; error?: Error; }[]; callCount: () => number; getCalls: () => any[]; reset: () => void; }; }",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [
+          "sendImpl"
+        ],
+        "typeCoveragePercent": 0,
+        "contentHash": "26b9e69d828da186",
+        "signatureHash": "e0034bf7029afb20"
+      }
+    },
+    {
+      "id": "function:createMockSDK.defaultSend:__tests__/12-scheduler.test.ts",
+      "type": "function",
+      "name": "createMockSDK.defaultSend",
+      "metadata": {
+        "filePath": "__tests__/12-scheduler.test.ts",
+        "lineNumber": 22,
+        "endLineNumber": 22,
+        "isAsync": true,
+        "isExported": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "eb45e52b2c7c42da",
+        "signatureHash": "41601a2f463f5a85"
+      }
+    },
+    {
+      "id": "module:13-security-injection.test:__tests__/13-security-injection.test.ts",
+      "type": "module",
+      "name": "13-security-injection.test",
+      "metadata": {
+        "filePath": "__tests__/13-security-injection.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:14-reactions.test:__tests__/14-reactions.test.ts",
+      "type": "module",
+      "name": "14-reactions.test",
+      "metadata": {
+        "filePath": "__tests__/14-reactions.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:15-tempfile-security.test:__tests__/15-tempfile-security.test.ts",
+      "type": "module",
+      "name": "15-tempfile-security.test",
+      "metadata": {
+        "filePath": "__tests__/15-tempfile-security.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:16-imessage-service-routing.test:__tests__/16-imessage-service-routing.test.ts",
+      "type": "module",
+      "name": "16-imessage-service-routing.test",
+      "metadata": {
+        "filePath": "__tests__/16-imessage-service-routing.test.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:setup:__tests__/setup.ts",
+      "type": "module",
+      "name": "setup",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:initTestDatabase:__tests__/setup.ts",
+      "type": "function",
+      "name": "initTestDatabase",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 20,
+        "endLineNumber": 32,
+        "isAsync": true,
+        "isExported": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 0,
+        "contentHash": "04a925c54fb0fe00",
+        "signatureHash": "cc364fd235a461a0"
+      }
+    },
+    {
+      "id": "function:createTempDir:__tests__/setup.ts",
+      "type": "function",
+      "name": "createTempDir",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 40,
+        "endLineNumber": 44,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "ccce4b719a99c136",
+        "signatureHash": "b4d08d51abdf2754"
+      }
+    },
+    {
+      "id": "function:cleanupTempDir:__tests__/setup.ts",
+      "type": "function",
+      "name": "cleanupTempDir",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 49,
+        "endLineNumber": 55,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "path"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "void",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 50,
+        "contentHash": "2a332176b64b7376",
+        "signatureHash": "e4cb83d0d096744d"
+      }
+    },
+    {
+      "id": "function:createMockDatabase:__tests__/setup.ts",
+      "type": "function",
+      "name": "createMockDatabase",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 60,
+        "endLineNumber": 128,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "{ db: any; path: string; cleanup: () => void; }",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 0,
+        "contentHash": "3a367ef68ce38b80",
+        "signatureHash": "24817e19b9aa39dc"
+      }
+    },
+    {
+      "id": "function:insertTestMessage:__tests__/setup.ts",
+      "type": "function",
+      "name": "insertTestMessage",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 133,
+        "endLineNumber": 232,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "db",
+          "options"
+        ],
+        "parameterTypes": [
+          "any",
+          "{ text: string; sender: string; isRead?: boolean; isFromMe?: boolean; service?: string; date?: number; chatGuid?: string; participants?: string[]; associatedMessageType?: number; associatedMessageGuid?: string; }"
+        ],
+        "returnType": "number",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [
+          "db"
+        ],
+        "typeCoveragePercent": 67,
+        "contentHash": "ccb0b51d40711dd9",
+        "signatureHash": "80364a3d723eb160"
+      }
+    },
+    {
+      "id": "function:mockAppleScript:__tests__/setup.ts",
+      "type": "function",
+      "name": "mockAppleScript",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 237,
+        "endLineNumber": 250,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "{ calls: { script: string; args: string[]; }[]; execute: (script: string, ...args: string[]) => Promise<string>; reset: () => void; }",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 0,
+        "contentHash": "fafa16ddb14539ce",
+        "signatureHash": "a357e7de9711b053"
+      }
+    },
+    {
+      "id": "function:waitFor:__tests__/setup.ts",
+      "type": "function",
+      "name": "waitFor",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 277,
+        "endLineNumber": 292,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "condition",
+          "timeout",
+          "interval"
+        ],
+        "parameterTypes": [
+          "() => boolean | Promise<boolean>",
+          "number",
+          "number"
+        ],
+        "returnType": "Promise<void>",
+        "hasExplicitInputTypes": false,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [
+          "timeout",
+          "interval"
+        ],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 50,
+        "contentHash": "c2bd7a0c61500ead",
+        "signatureHash": "4f02099cbf6a086d"
+      }
+    },
+    {
+      "id": "function:createSpy:__tests__/setup.ts",
+      "type": "function",
+      "name": "createSpy",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 297,
+        "endLineNumber": 318,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "implementation"
+        ],
+        "parameterTypes": [
+          "T"
+        ],
+        "returnType": "{ fn: T; calls: { args: Parameters<T>; result?: ReturnType<T>; error?: Error; }[]; callCount: () => number; getCalls: () => any[]; reset: () => void; }",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 50,
+        "contentHash": "3cc2e6d128989bcc",
+        "signatureHash": "a3978f126ec46fe1",
+        "calledBy": [
+          "function:createMockSDK:__tests__/12-scheduler.test.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:createMockDatabase.cleanup:__tests__/setup.ts",
+      "type": "function",
+      "name": "createMockDatabase.cleanup",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 120,
+        "endLineNumber": 125,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 0,
+        "contentHash": "07ee15da39e99aa2",
+        "signatureHash": "0f873ee2af8f6018"
+      }
+    },
+    {
+      "id": "class:MockWebhookServer:__tests__/setup.ts",
+      "type": "class",
+      "name": "MockWebhookServer",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 255,
+        "endLineNumber": 272,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:MockWebhookServer.getRequests:__tests__/setup.ts",
+      "type": "function",
+      "name": "MockWebhookServer.getRequests",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 260,
+        "endLineNumber": 262,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "{ body: any; headers: Record<string, string>; }[]",
+        "contentHash": "8ac33bb77d38440f",
+        "signatureHash": "7b6d04b2af6fed39",
+        "className": "MockWebhookServer"
+      }
+    },
+    {
+      "id": "function:MockWebhookServer.reset:__tests__/setup.ts",
+      "type": "function",
+      "name": "MockWebhookServer.reset",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 264,
+        "endLineNumber": 266,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "637b117200c96950",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "MockWebhookServer"
+      }
+    },
+    {
+      "id": "function:MockWebhookServer.receive:__tests__/setup.ts",
+      "type": "function",
+      "name": "MockWebhookServer.receive",
+      "metadata": {
+        "filePath": "__tests__/setup.ts",
+        "lineNumber": 269,
+        "endLineNumber": 271,
+        "isAsync": true,
+        "parameters": [
+          "body",
+          "headers"
+        ],
+        "parameterTypes": [
+          "any",
+          "Record<string, string>"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "d0a6907025c79b2c",
+        "signatureHash": "78bef6f3584aafe4",
+        "className": "MockWebhookServer"
+      }
+    },
+    {
+      "id": "module:01-send-text:examples/01-send-text.ts",
+      "type": "module",
+      "name": "01-send-text",
+      "metadata": {
+        "filePath": "examples/01-send-text.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "kafka-producer:pilot_photon.codes:examples/01-send-text.ts",
+      "type": "kafka-producer",
+      "name": "Producer: pilot@photon.codes",
+      "metadata": {
+        "filePath": "examples/01-send-text.ts",
+        "lineNumber": 6,
+        "kafkaTopic": "pilot@photon.codes"
+      }
+    },
+    {
+      "id": "kafka-producer:Hello_World:examples/01-send-text.ts",
+      "type": "kafka-producer",
+      "name": "Producer: Hello World",
+      "metadata": {
+        "filePath": "examples/01-send-text.ts",
+        "lineNumber": 6,
+        "kafkaTopic": "Hello World"
+      }
+    },
+    {
+      "id": "module:02-send-image:examples/02-send-image.ts",
+      "type": "module",
+      "name": "02-send-image",
+      "metadata": {
+        "filePath": "examples/02-send-image.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "kafka-producer:pilot_photon.codes:examples/02-send-image.ts",
+      "type": "kafka-producer",
+      "name": "Producer: pilot@photon.codes",
+      "metadata": {
+        "filePath": "examples/02-send-image.ts",
+        "lineNumber": 6,
+        "kafkaTopic": "pilot@photon.codes"
+      }
+    },
+    {
+      "id": "module:03-send-file:examples/03-send-file.ts",
+      "type": "module",
+      "name": "03-send-file",
+      "metadata": {
+        "filePath": "examples/03-send-file.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "kafka-producer:pilot_photon.codes:examples/03-send-file.ts",
+      "type": "kafka-producer",
+      "name": "Producer: pilot@photon.codes",
+      "metadata": {
+        "filePath": "examples/03-send-file.ts",
+        "lineNumber": 6,
+        "kafkaTopic": "pilot@photon.codes"
+      }
+    },
+    {
+      "id": "module:04-send-group:examples/04-send-group.ts",
+      "type": "module",
+      "name": "04-send-group",
+      "metadata": {
+        "filePath": "examples/04-send-group.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "kafka-producer:iMessage___chat493787071395575843:examples/04-send-group.ts",
+      "type": "kafka-producer",
+      "name": "Producer: iMessage;+;chat493787071395575843",
+      "metadata": {
+        "filePath": "examples/04-send-group.ts",
+        "lineNumber": 6,
+        "kafkaTopic": "iMessage;+;chat493787071395575843"
+      }
+    },
+    {
+      "id": "kafka-producer:Hello_everyone:examples/04-send-group.ts",
+      "type": "kafka-producer",
+      "name": "Producer: Hello everyone",
+      "metadata": {
+        "filePath": "examples/04-send-group.ts",
+        "lineNumber": 6,
+        "kafkaTopic": "Hello everyone"
+      }
+    },
+    {
+      "id": "module:05-query-messages:examples/05-query-messages.ts",
+      "type": "module",
+      "name": "05-query-messages",
+      "metadata": {
+        "filePath": "examples/05-query-messages.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:06-list-chats:examples/06-list-chats.ts",
+      "type": "module",
+      "name": "06-list-chats",
+      "metadata": {
+        "filePath": "examples/06-list-chats.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:07-watch-messages:examples/07-watch-messages.ts",
+      "type": "module",
+      "name": "07-watch-messages",
+      "metadata": {
+        "filePath": "examples/07-watch-messages.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:08-auto-reply:examples/08-auto-reply.ts",
+      "type": "module",
+      "name": "08-auto-reply",
+      "metadata": {
+        "filePath": "examples/08-auto-reply.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:09-batch-send:examples/09-batch-send.ts",
+      "type": "module",
+      "name": "09-batch-send",
+      "metadata": {
+        "filePath": "examples/09-batch-send.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:10-get-sent-message:examples/10-get-sent-message.ts",
+      "type": "module",
+      "name": "10-get-sent-message",
+      "metadata": {
+        "filePath": "examples/10-get-sent-message.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "kafka-producer:pilot_photon.codes:examples/10-get-sent-message.ts",
+      "type": "kafka-producer",
+      "name": "Producer: pilot@photon.codes",
+      "metadata": {
+        "filePath": "examples/10-get-sent-message.ts",
+        "lineNumber": 9,
+        "kafkaTopic": "pilot@photon.codes"
+      }
+    },
+    {
+      "id": "kafka-producer:Test_message:examples/10-get-sent-message.ts",
+      "type": "kafka-producer",
+      "name": "Producer: Test message",
+      "metadata": {
+        "filePath": "examples/10-get-sent-message.ts",
+        "lineNumber": 9,
+        "kafkaTopic": "Test message"
+      }
+    },
+    {
+      "id": "module:11-plugin:examples/11-plugin.ts",
+      "type": "module",
+      "name": "11-plugin",
+      "metadata": {
+        "filePath": "examples/11-plugin.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "kafka-producer:pilot_photon.codes:examples/11-plugin.ts",
+      "type": "kafka-producer",
+      "name": "Producer: pilot@photon.codes",
+      "metadata": {
+        "filePath": "examples/11-plugin.ts",
+        "lineNumber": 21,
+        "kafkaTopic": "pilot@photon.codes"
+      }
+    },
+    {
+      "id": "kafka-producer:Test_with_plugin:examples/11-plugin.ts",
+      "type": "kafka-producer",
+      "name": "Producer: Test with plugin",
+      "metadata": {
+        "filePath": "examples/11-plugin.ts",
+        "lineNumber": 21,
+        "kafkaTopic": "Test with plugin"
+      }
+    },
+    {
+      "id": "module:12-error-handling:examples/12-error-handling.ts",
+      "type": "module",
+      "name": "12-error-handling",
+      "metadata": {
+        "filePath": "examples/12-error-handling.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "kafka-producer:invalid-recipient:examples/12-error-handling.ts",
+      "type": "kafka-producer",
+      "name": "Producer: invalid-recipient",
+      "metadata": {
+        "filePath": "examples/12-error-handling.ts",
+        "lineNumber": 6,
+        "kafkaTopic": "invalid-recipient"
+      }
+    },
+    {
+      "id": "kafka-producer:Test:examples/12-error-handling.ts",
+      "type": "kafka-producer",
+      "name": "Producer: Test",
+      "metadata": {
+        "filePath": "examples/12-error-handling.ts",
+        "lineNumber": 6,
+        "kafkaTopic": "Test"
+      }
+    },
+    {
+      "id": "module:13-watch-own-messages:examples/13-watch-own-messages.ts",
+      "type": "module",
+      "name": "13-watch-own-messages",
+      "metadata": {
+        "filePath": "examples/13-watch-own-messages.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:14-scheduled-messages:examples/14-scheduled-messages.ts",
+      "type": "module",
+      "name": "14-scheduled-messages",
+      "metadata": {
+        "filePath": "examples/14-scheduled-messages.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:15-smart-reminders:examples/15-smart-reminders.ts",
+      "type": "module",
+      "name": "15-smart-reminders",
+      "metadata": {
+        "filePath": "examples/15-smart-reminders.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:index:src/index.ts",
+      "type": "module",
+      "name": "index",
+      "metadata": {
+        "filePath": "src/index.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:chain:src/core/chain.ts",
+      "type": "module",
+      "name": "chain",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "class:MessageChain:src/core/chain.ts",
+      "type": "class",
+      "name": "MessageChain",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 25,
+        "endLineNumber": 199,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:MessageChain.when:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.when",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 59,
+        "endLineNumber": 64,
+        "isAsync": false,
+        "parameters": [
+          "predicate"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/advanced\").Predicate<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message>"
+        ],
+        "returnType": "this",
+        "contentHash": "27d3b87e26442f85",
+        "signatureHash": "8d6751ae42223e04",
+        "className": "MessageChain",
+        "calledBy": [
+          "function:MessageChain.matchText:src/core/chain.ts",
+          "function:MessageChain.ifUnread:src/core/chain.ts",
+          "function:MessageChain.ifFromOthers:src/core/chain.ts",
+          "function:MessageChain.ifFromMe:src/core/chain.ts",
+          "function:MessageChain.ifGroupChat:src/core/chain.ts",
+          "function:MessageChain.ifReaction:src/core/chain.ts",
+          "function:MessageChain.ifNotReaction:src/core/chain.ts"
+        ],
+        "impactScore": 7
+      }
+    },
+    {
+      "id": "function:MessageChain.matchText:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.matchText",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 69,
+        "endLineNumber": 74,
+        "isAsync": false,
+        "parameters": [
+          "pattern"
+        ],
+        "parameterTypes": [
+          "string | RegExp"
+        ],
+        "returnType": "this",
+        "contentHash": "166bff2d1517c7d5",
+        "signatureHash": "f19020911c5a5456",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.ifUnread:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.ifUnread",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 79,
+        "endLineNumber": 81,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "this",
+        "contentHash": "de4691a1675ad518",
+        "signatureHash": "e961d46afefe6562",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.ifFromOthers:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.ifFromOthers",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 86,
+        "endLineNumber": 88,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "this",
+        "contentHash": "9e568e52a0f18638",
+        "signatureHash": "e961d46afefe6562",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.ifFromMe:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.ifFromMe",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 93,
+        "endLineNumber": 95,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "this",
+        "contentHash": "207856da772f0c0e",
+        "signatureHash": "e961d46afefe6562",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.ifGroupChat:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.ifGroupChat",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 100,
+        "endLineNumber": 102,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "this",
+        "contentHash": "3a27b843ad8782ee",
+        "signatureHash": "e961d46afefe6562",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.ifReaction:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.ifReaction",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 107,
+        "endLineNumber": 109,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "this",
+        "contentHash": "033ebdca7cbf1588",
+        "signatureHash": "e961d46afefe6562",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.ifNotReaction:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.ifNotReaction",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 114,
+        "endLineNumber": 116,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "this",
+        "contentHash": "f3ca9b18cfc3e4fd",
+        "signatureHash": "e961d46afefe6562",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.replyText:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.replyText",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 123,
+        "endLineNumber": 141,
+        "isAsync": false,
+        "parameters": [
+          "text"
+        ],
+        "parameterTypes": [
+          "string | import(\"/Users/mason/Documents/imessage-kit/src/types/advanced\").Mapper<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message, string>"
+        ],
+        "returnType": "this",
+        "contentHash": "1fcd147e67eca8ad",
+        "signatureHash": "75e8544362d54247",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.replyImage:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.replyImage",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 148,
+        "endLineNumber": 167,
+        "isAsync": false,
+        "parameters": [
+          "images"
+        ],
+        "parameterTypes": [
+          "string | string[] | import(\"/Users/mason/Documents/imessage-kit/src/types/advanced\").Mapper<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message, string | string[]>"
+        ],
+        "returnType": "this",
+        "contentHash": "b1e018dfe2460d09",
+        "signatureHash": "e174ab1fbc7a9ad4",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.do:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.do",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 172,
+        "endLineNumber": 179,
+        "isAsync": false,
+        "parameters": [
+          "handler"
+        ],
+        "parameterTypes": [
+          "(message: import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message) => void | Promise<void>"
+        ],
+        "returnType": "this",
+        "contentHash": "74e7b2c4405098ff",
+        "signatureHash": "6247b0e0a0013995",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "function:MessageChain.execute:src/core/chain.ts",
+      "type": "function",
+      "name": "MessageChain.execute",
+      "metadata": {
+        "filePath": "src/core/chain.ts",
+        "lineNumber": 188,
+        "endLineNumber": 198,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "b637d42bf8562123",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "MessageChain"
+      }
+    },
+    {
+      "id": "module:constants:src/core/constants.ts",
+      "type": "module",
+      "name": "constants",
+      "metadata": {
+        "filePath": "src/core/constants.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:database:src/core/database.ts",
+      "type": "module",
+      "name": "database",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:initDatabase:src/core/database.ts",
+      "type": "function",
+      "name": "initDatabase",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 37,
+        "endLineNumber": 57,
+        "isAsync": true,
+        "isExported": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 0,
+        "contentHash": "85c39bfe5f1f70e3",
+        "signatureHash": "cc364fd235a461a0",
+        "calledBy": [
+          "function:IMessageDatabase.init:src/core/database.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:str:src/core/database.ts",
+      "type": "function",
+      "name": "str",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 25,
+        "endLineNumber": 25,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "v",
+          "fallback"
+        ],
+        "parameterTypes": [
+          "unknown",
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": false,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [
+          "fallback"
+        ],
+        "weakTypeParams": [
+          "v"
+        ],
+        "typeCoveragePercent": 33,
+        "contentHash": "0037a9522eee5794",
+        "signatureHash": "26bdf21dfa528f7c",
+        "calledBy": [
+          "function:IMessageDatabase.rowToMessage:src/core/database.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:num:src/core/database.ts",
+      "type": "function",
+      "name": "num",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 26,
+        "endLineNumber": 26,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "v",
+          "fallback"
+        ],
+        "parameterTypes": [
+          "unknown",
+          "number"
+        ],
+        "returnType": "number",
+        "hasExplicitInputTypes": false,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [
+          "fallback"
+        ],
+        "weakTypeParams": [
+          "v"
+        ],
+        "typeCoveragePercent": 33,
+        "contentHash": "419ccf31c3a1370f",
+        "signatureHash": "b782b215445a5f40"
+      }
+    },
+    {
+      "id": "function:bool:src/core/database.ts",
+      "type": "function",
+      "name": "bool",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 27,
+        "endLineNumber": 27,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "v"
+        ],
+        "parameterTypes": [
+          "unknown"
+        ],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [
+          "v"
+        ],
+        "typeCoveragePercent": 50,
+        "contentHash": "544317c4239f0938",
+        "signatureHash": "4e09c3abebdd1bba",
+        "calledBy": [
+          "function:IMessageDatabase.rowToMessage:src/core/database.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "class:IMessageDatabase:src/core/database.ts",
+      "type": "class",
+      "name": "IMessageDatabase",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 62,
+        "endLineNumber": 612,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.init:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.init",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 82,
+        "endLineNumber": 91,
+        "isAsync": true,
+        "parameters": [
+          "path"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "dc533035314d1a23",
+        "signatureHash": "a0243696d6c4db6b",
+        "className": "IMessageDatabase"
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.ensureInit:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.ensureInit",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 96,
+        "endLineNumber": 98,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "473bf6b95ea85079",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:IMessageDatabase.getMessages:src/core/database.ts",
+          "function:IMessageDatabase.listChats:src/core/database.ts",
+          "function:IMessageDatabase.getAttachments:src/core/database.ts",
+          "function:IMessageDatabase.close:src/core/database.ts"
+        ],
+        "impactScore": 8
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.getMessages:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.getMessages",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 129,
+        "endLineNumber": 238,
+        "isAsync": true,
+        "parameters": [
+          "filter"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").MessageFilter"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").MessageQueryResult>",
+        "contentHash": "4d65c5c9d719b725",
+        "signatureHash": "5d38e04e9e34df05",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:IMessageDatabase.getUnreadMessages:src/core/database.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.getUnreadMessages:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.getUnreadMessages",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 254,
+        "endLineNumber": 268,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<{ grouped: Map<string, import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message[]>; total: number; }>",
+        "contentHash": "86009711856bda60",
+        "signatureHash": "81b1a359644d3593",
+        "className": "IMessageDatabase"
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.listChats:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.listChats",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 286,
+        "endLineNumber": 388,
+        "isAsync": true,
+        "parameters": [
+          "options"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").ListChatsOptions"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").ChatSummary[]>",
+        "contentHash": "eb38849efd82a0e8",
+        "signatureHash": "8724dae0bf62a8c3",
+        "className": "IMessageDatabase"
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.getAttachments:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.getAttachments",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 395,
+        "endLineNumber": 439,
+        "isAsync": true,
+        "parameters": [
+          "messageId"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment[]>",
+        "contentHash": "eb5724daf93b8803",
+        "signatureHash": "ca6d187c669a68d5",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:IMessageDatabase.rowToMessage:src/core/database.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.extractTextFromAttributedBody:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.extractTextFromAttributedBody",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 447,
+        "endLineNumber": 490,
+        "isAsync": false,
+        "parameters": [
+          "attributedBody"
+        ],
+        "parameterTypes": [
+          "unknown"
+        ],
+        "returnType": "string",
+        "contentHash": "654c909e89e1ae2c",
+        "signatureHash": "8c691a4386bb72cb",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+          "function:extractTextFromAttributedBody:__tests__/12-attributed-body.test.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.rowToMessage",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 497,
+        "endLineNumber": 534,
+        "isAsync": true,
+        "parameters": [
+          "row"
+        ],
+        "parameterTypes": [
+          "Record<string, unknown>"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message>",
+        "contentHash": "44367ab39dec05f8",
+        "signatureHash": "1db8f0551767d814",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:IMessageDatabase.getMessages.messages:src/core/database.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.mapService:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.mapService",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 541,
+        "endLineNumber": 547,
+        "isAsync": false,
+        "parameters": [
+          "service"
+        ],
+        "parameterTypes": [
+          "unknown"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").ServiceType",
+        "contentHash": "ac208c1dc813896f",
+        "signatureHash": "e8bd9902703e5eae",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:IMessageDatabase.rowToMessage:src/core/database.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.mapReactionType:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.mapReactionType",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 554,
+        "endLineNumber": 591,
+        "isAsync": false,
+        "parameters": [
+          "type"
+        ],
+        "parameterTypes": [
+          "unknown"
+        ],
+        "returnType": "{ isReaction: boolean; reactionType: import(\"/Users/mason/Documents/imessage-kit/src/types/message\").ReactionType; isReactionRemoval: boolean; }",
+        "contentHash": "ff7a19b26b0b5bbc",
+        "signatureHash": "664a76064474479f",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:IMessageDatabase.rowToMessage:src/core/database.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.convertMacTimestamp:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.convertMacTimestamp",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 600,
+        "endLineNumber": 603,
+        "isAsync": false,
+        "parameters": [
+          "timestamp"
+        ],
+        "parameterTypes": [
+          "unknown"
+        ],
+        "returnType": "Date",
+        "contentHash": "4b126cd49bbbd43d",
+        "signatureHash": "5b8497e3ee7121d0",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:IMessageDatabase.rowToMessage:src/core/database.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:IMessageDatabase.close:src/core/database.ts",
+      "type": "function",
+      "name": "IMessageDatabase.close",
+      "metadata": {
+        "filePath": "src/core/database.ts",
+        "lineNumber": 608,
+        "endLineNumber": 611,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "14663e59a2a0c189",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "IMessageDatabase",
+        "calledBy": [
+          "function:createMockDatabase:__tests__/setup.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "module:errors:src/core/errors.ts",
+      "type": "module",
+      "name": "errors",
+      "metadata": {
+        "filePath": "src/core/errors.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:PlatformError:src/core/errors.ts",
+      "type": "function",
+      "name": "PlatformError",
+      "metadata": {
+        "filePath": "src/core/errors.ts",
+        "lineNumber": 34,
+        "endLineNumber": 35,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "msg",
+          "cause"
+        ],
+        "parameterTypes": [
+          "string",
+          "Error"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/core/errors\").IMessageError",
+        "hasExplicitInputTypes": false,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [
+          "msg"
+        ],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 33,
+        "contentHash": "db956949a811f961",
+        "signatureHash": "7141ab1e2ebff6b5",
+        "calledBy": [
+          "function:requireMacOS:src/utils/platform.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:DatabaseError:src/core/errors.ts",
+      "type": "function",
+      "name": "DatabaseError",
+      "metadata": {
+        "filePath": "src/core/errors.ts",
+        "lineNumber": 36,
+        "endLineNumber": 37,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "msg",
+          "cause"
+        ],
+        "parameterTypes": [
+          "string",
+          "Error"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/core/errors\").IMessageError",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 67,
+        "contentHash": "943f44767e91f20e",
+        "signatureHash": "7141ab1e2ebff6b5",
+        "calledBy": [
+          "function:initDatabase:src/core/database.ts",
+          "function:IMessageDatabase.init:src/core/database.ts",
+          "function:IMessageDatabase.getMessages:src/core/database.ts",
+          "function:IMessageDatabase.listChats:src/core/database.ts"
+        ],
+        "impactScore": 6
+      }
+    },
+    {
+      "id": "function:SendError:src/core/errors.ts",
+      "type": "function",
+      "name": "SendError",
+      "metadata": {
+        "filePath": "src/core/errors.ts",
+        "lineNumber": 38,
+        "endLineNumber": 38,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "msg",
+          "cause"
+        ],
+        "parameterTypes": [
+          "string",
+          "Error"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/core/errors\").IMessageError",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 67,
+        "contentHash": "4deea1a96f3c7ec2",
+        "signatureHash": "7141ab1e2ebff6b5",
+        "calledBy": [
+          "function:MessageSender.executeWithRetry:src/core/sender.ts",
+          "function:MessageSender.resolveAttachment:src/core/sender.ts",
+          "function:MessageSender.send.task:src/core/sender.ts",
+          "function:MessageSender.checkAbortSignal:src/core/sender.ts",
+          "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts",
+          "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+          "function:convertImageToJPEG:src/utils/download.ts",
+          "function:downloadImage:src/utils/download.ts"
+        ],
+        "impactScore": 22
+      }
+    },
+    {
+      "id": "function:WebhookError:src/core/errors.ts",
+      "type": "function",
+      "name": "WebhookError",
+      "metadata": {
+        "filePath": "src/core/errors.ts",
+        "lineNumber": 39,
+        "endLineNumber": 40,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "msg",
+          "cause"
+        ],
+        "parameterTypes": [
+          "string",
+          "Error"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/core/errors\").IMessageError",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 67,
+        "contentHash": "90a5fecf9e32f6a2",
+        "signatureHash": "7141ab1e2ebff6b5",
+        "calledBy": [
+          "function:MessageWatcher.sendWebhook:src/core/watcher.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:ConfigError:src/core/errors.ts",
+      "type": "function",
+      "name": "ConfigError",
+      "metadata": {
+        "filePath": "src/core/errors.ts",
+        "lineNumber": 41,
+        "endLineNumber": 42,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "msg",
+          "cause"
+        ],
+        "parameterTypes": [
+          "string",
+          "Error"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/core/errors\").IMessageError",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 67,
+        "contentHash": "dbd17a686881508e",
+        "signatureHash": "7141ab1e2ebff6b5"
+      }
+    },
+    {
+      "id": "class:IMessageError:src/core/errors.ts",
+      "type": "class",
+      "name": "IMessageError",
+      "metadata": {
+        "filePath": "src/core/errors.ts",
+        "lineNumber": 11,
+        "endLineNumber": 31,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:IMessageError.is:src/core/errors.ts",
+      "type": "function",
+      "name": "IMessageError.is",
+      "metadata": {
+        "filePath": "src/core/errors.ts",
+        "lineNumber": 28,
+        "endLineNumber": 30,
+        "isAsync": false,
+        "parameters": [
+          "code"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/core/errors\").ErrorCode"
+        ],
+        "returnType": "boolean",
+        "contentHash": "62f5f8fa53ed1513",
+        "signatureHash": "4ff38914f0e003e2",
+        "className": "IMessageError"
+      }
+    },
+    {
+      "id": "module:message-promise:src/core/message-promise.ts",
+      "type": "module",
+      "name": "message-promise",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "class:MessagePromiseRejection:src/core/message-promise.ts",
+      "type": "class",
+      "name": "MessagePromiseRejection",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 9,
+        "endLineNumber": 22,
+        "isExported": true
+      }
+    },
+    {
+      "id": "class:MessagePromise:src/core/message-promise.ts",
+      "type": "class",
+      "name": "MessagePromise",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 36,
+        "endLineNumber": 235,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:MessagePromise.normalizeText:src/core/message-promise.ts",
+      "type": "function",
+      "name": "MessagePromise.normalizeText",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 91,
+        "endLineNumber": 93,
+        "isAsync": false,
+        "parameters": [
+          "text"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "contentHash": "1cf304c3c987894e",
+        "signatureHash": "90763fd9cea61b77",
+        "className": "MessagePromise",
+        "calledBy": [
+          "function:MessagePromise.matches:src/core/message-promise.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:MessagePromise.getFilenameWithoutExtension:src/core/message-promise.ts",
+      "type": "function",
+      "name": "MessagePromise.getFilenameWithoutExtension",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 98,
+        "endLineNumber": 102,
+        "isAsync": false,
+        "parameters": [
+          "filename"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "contentHash": "33f134d37931d4f6",
+        "signatureHash": "2e1435e3b4b6a796",
+        "className": "MessagePromise",
+        "calledBy": [
+          "function:MessagePromise.matches:src/core/message-promise.ts",
+          "function:MessagePromise.matches.match:src/core/message-promise.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "type": "function",
+      "name": "MessagePromise.resolve",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 107,
+        "endLineNumber": 113,
+        "isAsync": false,
+        "parameters": [
+          "message"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message"
+        ],
+        "returnType": "void",
+        "contentHash": "74ea3352af4ca177",
+        "signatureHash": "9e2ed86f7444ba5d",
+        "className": "MessagePromise",
+        "calledBy": [
+          "function:sendSpy:__tests__/06-sdk-core.test.ts",
+          "function:OutgoingMessageManager.tryResolve:src/core/outgoing-manager.ts",
+          "function:MessageSender.resolveAttachment:src/core/sender.ts",
+          "function:PluginManager.use:src/plugins/core.ts",
+          "function:PluginManager.callHookForAll.results:src/plugins/core.ts",
+          "function:PluginManager.callHookForAll:src/plugins/core.ts",
+          "function:MessageChain.do:src/core/chain.ts"
+        ],
+        "impactScore": 28
+      }
+    },
+    {
+      "id": "function:MessagePromise.reject:src/core/message-promise.ts",
+      "type": "function",
+      "name": "MessagePromise.reject",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 118,
+        "endLineNumber": 124,
+        "isAsync": false,
+        "parameters": [
+          "reason",
+          "message"
+        ],
+        "parameterTypes": [
+          "string",
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message"
+        ],
+        "returnType": "void",
+        "contentHash": "5d9eb2327fddcfdc",
+        "signatureHash": "01701cdcf1771ac3",
+        "className": "MessagePromise",
+        "calledBy": [
+          "function:OutgoingMessageManager.rejectAll:src/core/outgoing-manager.ts"
+        ],
+        "impactScore": 5
+      }
+    },
+    {
+      "id": "function:MessagePromise.matches:src/core/message-promise.ts",
+      "type": "function",
+      "name": "MessagePromise.matches",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 129,
+        "endLineNumber": 189,
+        "isAsync": false,
+        "parameters": [
+          "message"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message"
+        ],
+        "returnType": "boolean",
+        "contentHash": "971a8d31a9f72b4d",
+        "signatureHash": "49f28bb810292d62",
+        "className": "MessagePromise",
+        "calledBy": [
+          "function:OutgoingMessageManager.tryResolve:src/core/outgoing-manager.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:MessagePromise.matchesChatId:src/core/message-promise.ts",
+      "type": "function",
+      "name": "MessagePromise.matchesChatId",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 194,
+        "endLineNumber": 203,
+        "isAsync": false,
+        "parameters": [
+          "chatId"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "boolean",
+        "contentHash": "6cb245ff9fd8ae0b",
+        "signatureHash": "4aaac0c21cd7e490",
+        "className": "MessagePromise",
+        "calledBy": [
+          "function:MessagePromise.matches:src/core/message-promise.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:MessagePromise.normalizeChatId:src/core/message-promise.ts",
+      "type": "function",
+      "name": "MessagePromise.normalizeChatId",
+      "metadata": {
+        "filePath": "src/core/message-promise.ts",
+        "lineNumber": 224,
+        "endLineNumber": 234,
+        "isAsync": false,
+        "parameters": [
+          "chatId"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "contentHash": "d75181e4b868e728",
+        "signatureHash": "4e734c0ad4105a85",
+        "className": "MessagePromise",
+        "calledBy": [
+          "function:MessagePromise.matchesChatId:src/core/message-promise.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "module:outgoing-manager:src/core/outgoing-manager.ts",
+      "type": "module",
+      "name": "outgoing-manager",
+      "metadata": {
+        "filePath": "src/core/outgoing-manager.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "class:OutgoingMessageManager:src/core/outgoing-manager.ts",
+      "type": "class",
+      "name": "OutgoingMessageManager",
+      "metadata": {
+        "filePath": "src/core/outgoing-manager.ts",
+        "lineNumber": 10,
+        "endLineNumber": 93,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:OutgoingMessageManager.add:src/core/outgoing-manager.ts",
+      "type": "function",
+      "name": "OutgoingMessageManager.add",
+      "metadata": {
+        "filePath": "src/core/outgoing-manager.ts",
+        "lineNumber": 21,
+        "endLineNumber": 29,
+        "isAsync": false,
+        "parameters": [
+          "promise"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/core/message-promise\").MessagePromise"
+        ],
+        "returnType": "void",
+        "contentHash": "d348e0901d760b8e",
+        "signatureHash": "2a34ae84f8101f20",
+        "className": "OutgoingMessageManager"
+      }
+    },
+    {
+      "id": "function:OutgoingMessageManager.tryResolve:src/core/outgoing-manager.ts",
+      "type": "function",
+      "name": "OutgoingMessageManager.tryResolve",
+      "metadata": {
+        "filePath": "src/core/outgoing-manager.ts",
+        "lineNumber": 35,
+        "endLineNumber": 58,
+        "isAsync": false,
+        "parameters": [
+          "message"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message"
+        ],
+        "returnType": "boolean",
+        "contentHash": "70063af0855a0a6f",
+        "signatureHash": "49f28bb810292d62",
+        "className": "OutgoingMessageManager"
+      }
+    },
+    {
+      "id": "function:OutgoingMessageManager.cleanup:src/core/outgoing-manager.ts",
+      "type": "function",
+      "name": "OutgoingMessageManager.cleanup",
+      "metadata": {
+        "filePath": "src/core/outgoing-manager.ts",
+        "lineNumber": 63,
+        "endLineNumber": 73,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "36d11ee591820ba9",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "OutgoingMessageManager"
+      }
+    },
+    {
+      "id": "function:OutgoingMessageManager.getPendingCount:src/core/outgoing-manager.ts",
+      "type": "function",
+      "name": "OutgoingMessageManager.getPendingCount",
+      "metadata": {
+        "filePath": "src/core/outgoing-manager.ts",
+        "lineNumber": 78,
+        "endLineNumber": 80,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "number",
+        "contentHash": "f86361874dc3dff3",
+        "signatureHash": "f4b49792b0071f74",
+        "className": "OutgoingMessageManager"
+      }
+    },
+    {
+      "id": "function:OutgoingMessageManager.rejectAll:src/core/outgoing-manager.ts",
+      "type": "function",
+      "name": "OutgoingMessageManager.rejectAll",
+      "metadata": {
+        "filePath": "src/core/outgoing-manager.ts",
+        "lineNumber": 85,
+        "endLineNumber": 92,
+        "isAsync": false,
+        "parameters": [
+          "reason"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "void",
+        "contentHash": "ccecf65f00ecec74",
+        "signatureHash": "5d62c023759a0ad3",
+        "className": "OutgoingMessageManager",
+        "calledBy": [
+          "function:IMessageSDK.close:src/core/sdk.ts"
+        ],
+        "impactScore": 4
+      }
+    },
+    {
+      "id": "module:sdk:src/core/sdk.ts",
+      "type": "module",
+      "name": "sdk",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:IMessageSDK.resolveConfig.clamp:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.resolveConfig.clamp",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 127,
+        "endLineNumber": 133,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "v",
+          "min",
+          "max",
+          "def"
+        ],
+        "parameterTypes": [
+          "number",
+          "number",
+          "number",
+          "number"
+        ],
+        "returnType": "number",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 80,
+        "contentHash": "03a11190d7e053f8",
+        "signatureHash": "50570835db095012",
+        "calledBy": [
+          "function:IMessageSDK.resolveConfig:src/core/sdk.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "class:IMessageSDK:src/core/sdk.ts",
+      "type": "class",
+      "name": "IMessageSDK",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 54,
+        "endLineNumber": 624,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:IMessageSDK.ensurePluginsReady:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.ensurePluginsReady",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 120,
+        "endLineNumber": 124,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "9bc9cb98f6d3b6e2",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "IMessageSDK",
+        "calledBy": [
+          "function:IMessageSDK.getMessages:src/core/sdk.ts",
+          "function:IMessageSDK.getUnreadMessages:src/core/sdk.ts",
+          "function:IMessageSDK.send:src/core/sdk.ts",
+          "function:IMessageSDK.listChats:src/core/sdk.ts"
+        ],
+        "impactScore": 7
+      }
+    },
+    {
+      "id": "function:IMessageSDK.resolveConfig:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.resolveConfig",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 126,
+        "endLineNumber": 157,
+        "isAsync": false,
+        "parameters": [
+          "config"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/config\").IMessageConfig"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/types/config\").ResolvedConfig",
+        "contentHash": "0bc16c7dc6f9186f",
+        "signatureHash": "b282bdbde77e7739",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.isChatId:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.isChatId",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 173,
+        "endLineNumber": 194,
+        "isAsync": false,
+        "parameters": [
+          "value"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "boolean",
+        "contentHash": "070d8e97a8ca3058",
+        "signatureHash": "b59f71b28547d043",
+        "className": "IMessageSDK",
+        "calledBy": [
+          "function:IMessageSDK.send:src/core/sdk.ts"
+        ],
+        "impactScore": 4
+      }
+    },
+    {
+      "id": "function:IMessageSDK.use:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.use",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 199,
+        "endLineNumber": 203,
+        "isAsync": false,
+        "parameters": [
+          "plugin"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/plugins/core\").Plugin"
+        ],
+        "returnType": "this",
+        "contentHash": "a30e466e25d23f5e",
+        "signatureHash": "b3d8f09ae602dce6",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.getMessages:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.getMessages",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 216,
+        "endLineNumber": 225,
+        "isAsync": true,
+        "parameters": [
+          "filter"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").MessageFilter"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").MessageQueryResult>",
+        "contentHash": "87b0c56d07f2ae0c",
+        "signatureHash": "5d38e04e9e34df05",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.getUnreadMessages:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.getUnreadMessages",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 240,
+        "endLineNumber": 263,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").UnreadMessagesResult>",
+        "contentHash": "8b54322aee1e4a9f",
+        "signatureHash": "b732fee1c8d59bd7",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.send:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.send",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 288,
+        "endLineNumber": 348,
+        "isAsync": true,
+        "parameters": [
+          "to",
+          "content"
+        ],
+        "parameterTypes": [
+          "string",
+          "string | { text?: string; images?: string[]; files?: string[]; }"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>",
+        "contentHash": "498ed4f2592bd17c",
+        "signatureHash": "395a992152564c49",
+        "className": "IMessageSDK",
+        "calledBy": [
+          "function:IMessageSDK.sendBatch.results:src/core/sdk.ts",
+          "function:IMessageSDK.sendFile:src/core/sdk.ts",
+          "function:IMessageSDK.sendFiles:src/core/sdk.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "function:IMessageSDK.listChats:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.listChats",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 378,
+        "endLineNumber": 391,
+        "isAsync": true,
+        "parameters": [
+          "options"
+        ],
+        "parameterTypes": [
+          "number | import(\"/Users/mason/Documents/imessage-kit/src/types/message\").ListChatsOptions"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/types/message\").ChatSummary[]>",
+        "contentHash": "eb9fad35b82abc55",
+        "signatureHash": "cc19924e319fce9d",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.sendBatch:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.sendBatch",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 415,
+        "endLineNumber": 453,
+        "isAsync": true,
+        "parameters": [
+          "messages"
+        ],
+        "parameterTypes": [
+          "{ to: string; content: string | { text?: string; images?: string[]; files?: string[]; }; }[]"
+        ],
+        "returnType": "Promise<{ to: string; success: boolean; result?: import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult; error?: Error; }[]>",
+        "contentHash": "cc4cd4c19d0fca9f",
+        "signatureHash": "0a77cadb66528c05",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.sendFile:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.sendFile",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 469,
+        "endLineNumber": 471,
+        "isAsync": true,
+        "parameters": [
+          "to",
+          "filePath",
+          "text"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "string"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>",
+        "contentHash": "5db98ae712ed67bf",
+        "signatureHash": "21ebdf8c60628179",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.sendFiles:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.sendFiles",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 487,
+        "endLineNumber": 489,
+        "isAsync": true,
+        "parameters": [
+          "to",
+          "filePaths",
+          "text"
+        ],
+        "parameterTypes": [
+          "string",
+          "string[]",
+          "string"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>",
+        "contentHash": "18585ecc5abcedad",
+        "signatureHash": "4a81378928deb3b2",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.message:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.message",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 496,
+        "endLineNumber": 499,
+        "isAsync": false,
+        "parameters": [
+          "message"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/core/chain\").MessageChain",
+        "contentHash": "537cfb625a7b3ef6",
+        "signatureHash": "0cf1d11400328f78",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.startWatching:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.startWatching",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 504,
+        "endLineNumber": 527,
+        "isAsync": true,
+        "parameters": [
+          "events"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/core/watcher\").WatcherEvents"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "af4d2a11f9f0dd06",
+        "signatureHash": "8b749c1b2104060d",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.stopWatching:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.stopWatching",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 532,
+        "endLineNumber": 535,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "813069e9044e5d81",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK.close:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.close",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 540,
+        "endLineNumber": 613,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "48d9f3fe773da8d5",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "IMessageSDK",
+        "calledBy": [
+          "function:IMessageSDK._Symbol.asyncDispose_:src/core/sdk.ts",
+          "function:IMessageSDK._Symbol.dispose_:src/core/sdk.ts",
+          "function:createMockDatabase.cleanup:__tests__/setup.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "function:IMessageSDK._Symbol.asyncDispose_:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.[Symbol.asyncDispose]",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 616,
+        "endLineNumber": 618,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "5f6b3c26f3cc2973",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "function:IMessageSDK._Symbol.dispose_:src/core/sdk.ts",
+      "type": "function",
+      "name": "IMessageSDK.[Symbol.dispose]",
+      "metadata": {
+        "filePath": "src/core/sdk.ts",
+        "lineNumber": 621,
+        "endLineNumber": 623,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "98ffe14497a9fb97",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "IMessageSDK"
+      }
+    },
+    {
+      "id": "module:sender:src/core/sender.ts",
+      "type": "module",
+      "name": "sender",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:MessageSender.send.task:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.send.task",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 159,
+        "endLineNumber": 243,
+        "isAsync": true,
+        "isExported": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<{ sentAt: Date; message: import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message; }>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 0,
+        "contentHash": "936e26c9e24b2742",
+        "signatureHash": "4af0fb8fa667e7b9",
+        "calledBy": [
+          "function:MessageSender.send:src/core/sender.ts",
+          "function:MessageSender.sendToGroup:src/core/sender.ts"
+        ],
+        "impactScore": 7
+      }
+    },
+    {
+      "id": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.sendToGroup.task",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 399,
+        "endLineNumber": 484,
+        "isAsync": true,
+        "isExported": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<{ sentAt: Date; message: import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message; }>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 0,
+        "contentHash": "8ec90cf0c2aa99b5",
+        "signatureHash": "4af0fb8fa667e7b9"
+      }
+    },
+    {
+      "id": "class:MessageSender:src/core/sender.ts",
+      "type": "class",
+      "name": "MessageSender",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 63,
+        "endLineNumber": 488,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:MessageSender.setOutgoingManager:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.setOutgoingManager",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 88,
+        "endLineNumber": 90,
+        "isAsync": false,
+        "parameters": [
+          "manager"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/core/outgoing-manager\").OutgoingMessageManager"
+        ],
+        "returnType": "void",
+        "contentHash": "56080880eb75a84c",
+        "signatureHash": "41e94a299fd72d9c",
+        "className": "MessageSender"
+      }
+    },
+    {
+      "id": "function:MessageSender.executeWithRetry:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.executeWithRetry",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 99,
+        "endLineNumber": 117,
+        "isAsync": true,
+        "parameters": [
+          "script",
+          "description"
+        ],
+        "parameterTypes": [
+          "string",
+          "string"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "ad1a8c9eb308518f",
+        "signatureHash": "21c90955ecbd7c3c",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:MessageSender.sendToRecipient:src/core/sender.ts",
+          "function:MessageSender.sendToGroupChat:src/core/sender.ts"
+        ],
+        "impactScore": 11
+      }
+    },
+    {
+      "id": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.resolveAttachment",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 131,
+        "endLineNumber": 153,
+        "isAsync": true,
+        "parameters": [
+          "path"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "Promise<string>",
+        "contentHash": "f08e1cb146c32cf1",
+        "signatureHash": "e264e8295706a53e",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:MessageSender.prepareAttachments:src/core/sender.ts"
+        ],
+        "impactScore": 10
+      }
+    },
+    {
+      "id": "function:MessageSender.send:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.send",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 158,
+        "endLineNumber": 246,
+        "isAsync": true,
+        "parameters": [
+          "options"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendOptions"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>",
+        "contentHash": "b47bf23ddecf35f6",
+        "signatureHash": "21a12cf9e5ef6eca",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:IMessageSDK.sendBatch:src/core/sdk.ts",
+          "function:MessageChain.replyText:src/core/chain.ts",
+          "function:MessageChain.replyImage:src/core/chain.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "function:MessageSender.checkAbortSignal:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.checkAbortSignal",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 251,
+        "endLineNumber": 255,
+        "isAsync": false,
+        "parameters": [
+          "signal"
+        ],
+        "parameterTypes": [
+          "AbortSignal"
+        ],
+        "returnType": "void",
+        "contentHash": "7fb842b4cac1cf9a",
+        "signatureHash": "cbbcdec396f09cb3",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:MessageSender.send.task:src/core/sender.ts",
+          "function:MessageSender.sendToGroup.task:src/core/sender.ts"
+        ],
+        "impactScore": 9
+      }
+    },
+    {
+      "id": "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.checkMessagesEnvironment",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 260,
+        "endLineNumber": 279,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "a817f01ad9e6d3ad",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:MessageSender.send.task:src/core/sender.ts",
+          "function:MessageSender.sendToGroup.task:src/core/sender.ts"
+        ],
+        "impactScore": 9
+      }
+    },
+    {
+      "id": "function:MessageSender.prepareAttachments:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.prepareAttachments",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 284,
+        "endLineNumber": 309,
+        "isAsync": true,
+        "parameters": [
+          "attachments"
+        ],
+        "parameterTypes": [
+          "readonly string[]"
+        ],
+        "returnType": "Promise<string[]>",
+        "contentHash": "ec90bde0fa2c0613",
+        "signatureHash": "baefac1ab61cba81",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:MessageSender.send.task:src/core/sender.ts",
+          "function:MessageSender.sendToGroup.task:src/core/sender.ts"
+        ],
+        "impactScore": 9
+      }
+    },
+    {
+      "id": "function:MessageSender.sendToRecipient:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.sendToRecipient",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 314,
+        "endLineNumber": 351,
+        "isAsync": true,
+        "parameters": [
+          "recipient",
+          "text",
+          "hasText",
+          "resolvedPaths"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "boolean",
+          "string[]"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "68a356539e5484b7",
+        "signatureHash": "6cdab7961735e2e9",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:MessageSender.send.task:src/core/sender.ts"
+        ],
+        "impactScore": 8
+      }
+    },
+    {
+      "id": "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.sendToGroupChat",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 356,
+        "endLineNumber": 393,
+        "isAsync": true,
+        "parameters": [
+          "groupId",
+          "text",
+          "hasText",
+          "resolvedPaths"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "boolean",
+          "string[]"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "18330b3e78b93ade",
+        "signatureHash": "8f74d8c3de644242",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:MessageSender.sendToGroup.task:src/core/sender.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:MessageSender.sendToGroup:src/core/sender.ts",
+      "type": "function",
+      "name": "MessageSender.sendToGroup",
+      "metadata": {
+        "filePath": "src/core/sender.ts",
+        "lineNumber": 398,
+        "endLineNumber": 487,
+        "isAsync": true,
+        "parameters": [
+          "options"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendToGroupOptions"
+        ],
+        "returnType": "Promise<import(\"/Users/mason/Documents/imessage-kit/src/core/sender\").SendResult>",
+        "contentHash": "17ff1fac19c1d6b9",
+        "signatureHash": "d4df9346ce5f8552",
+        "className": "MessageSender",
+        "calledBy": [
+          "function:MessageChain.replyText:src/core/chain.ts",
+          "function:MessageChain.replyImage:src/core/chain.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "module:watcher:src/core/watcher.ts",
+      "type": "module",
+      "name": "watcher",
+      "metadata": {
+        "filePath": "src/core/watcher.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "class:MessageWatcher:src/core/watcher.ts",
+      "type": "class",
+      "name": "MessageWatcher",
+      "metadata": {
+        "filePath": "src/core/watcher.ts",
+        "lineNumber": 30,
+        "endLineNumber": 279,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:MessageWatcher.start:src/core/watcher.ts",
+      "type": "function",
+      "name": "MessageWatcher.start",
+      "metadata": {
+        "filePath": "src/core/watcher.ts",
+        "lineNumber": 63,
+        "endLineNumber": 83,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "6581b9a7d60e0ddf",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "MessageWatcher",
+        "calledBy": [
+          "function:IMessageSDK.startWatching:src/core/sdk.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:MessageWatcher.stop:src/core/watcher.ts",
+      "type": "function",
+      "name": "MessageWatcher.stop",
+      "metadata": {
+        "filePath": "src/core/watcher.ts",
+        "lineNumber": 88,
+        "endLineNumber": 100,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "3b72928d5b397cfa",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "MessageWatcher",
+        "calledBy": [
+          "function:IMessageSDK.startWatching:src/core/sdk.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:MessageWatcher.check:src/core/watcher.ts",
+      "type": "function",
+      "name": "MessageWatcher.check",
+      "metadata": {
+        "filePath": "src/core/watcher.ts",
+        "lineNumber": 105,
+        "endLineNumber": 176,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "dc4126341db863e9",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "MessageWatcher",
+        "calledBy": [
+          "function:MessageWatcher.start:src/core/watcher.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:MessageWatcher.handleNewMessage:src/core/watcher.ts",
+      "type": "function",
+      "name": "MessageWatcher.handleNewMessage",
+      "metadata": {
+        "filePath": "src/core/watcher.ts",
+        "lineNumber": 183,
+        "endLineNumber": 203,
+        "isAsync": true,
+        "parameters": [
+          "message"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "4b41c16c3fe4f387",
+        "signatureHash": "36de9f3994a8778b",
+        "className": "MessageWatcher"
+      }
+    },
+    {
+      "id": "function:MessageWatcher.sendWebhook:src/core/watcher.ts",
+      "type": "function",
+      "name": "MessageWatcher.sendWebhook",
+      "metadata": {
+        "filePath": "src/core/watcher.ts",
+        "lineNumber": 210,
+        "endLineNumber": 265,
+        "isAsync": true,
+        "parameters": [
+          "message"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Message"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "09f62ec2545b5aba",
+        "signatureHash": "36de9f3994a8778b",
+        "className": "MessageWatcher",
+        "calledBy": [
+          "function:MessageWatcher.handleNewMessage:src/core/watcher.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:MessageWatcher.handleError:src/core/watcher.ts",
+      "type": "function",
+      "name": "MessageWatcher.handleError",
+      "metadata": {
+        "filePath": "src/core/watcher.ts",
+        "lineNumber": 272,
+        "endLineNumber": 278,
+        "isAsync": false,
+        "parameters": [
+          "error"
+        ],
+        "parameterTypes": [
+          "unknown"
+        ],
+        "returnType": "void",
+        "contentHash": "dca51152a21cdc85",
+        "signatureHash": "30fb695108040d9c",
+        "className": "MessageWatcher",
+        "calledBy": [
+          "function:MessageWatcher.check:src/core/watcher.ts",
+          "function:MessageWatcher.handleNewMessage:src/core/watcher.ts"
+        ],
+        "impactScore": 4
+      }
+    },
+    {
+      "id": "module:attachment:src/helpers/attachment.ts",
+      "type": "module",
+      "name": "attachment",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:attachmentExists:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "attachmentExists",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 40,
+        "endLineNumber": 47,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "attachment"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment"
+        ],
+        "returnType": "Promise<boolean>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "e60e8063fb8aa248",
+        "signatureHash": "57b0c55ff03d752c"
+      }
+    },
+    {
+      "id": "function:downloadAttachment:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "downloadAttachment",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 64,
+        "endLineNumber": 71,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "attachment",
+          "destPath"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment",
+          "string"
+        ],
+        "returnType": "Promise<void>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "6d304ac0ed6a055e",
+        "signatureHash": "24708fe3fa539e87"
+      }
+    },
+    {
+      "id": "function:getAttachmentSize:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "getAttachmentSize",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 87,
+        "endLineNumber": 94,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "attachment"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment"
+        ],
+        "returnType": "Promise<number>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "3384c1e33cc62a2f",
+        "signatureHash": "a23908e94ba2011c"
+      }
+    },
+    {
+      "id": "function:getAttachmentMetadata:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "getAttachmentMetadata",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 112,
+        "endLineNumber": 118,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "attachment"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment"
+        ],
+        "returnType": "Promise<any>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "cb809785ff935e01",
+        "signatureHash": "82d2ae2af115464e"
+      }
+    },
+    {
+      "id": "function:readAttachment:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "readAttachment",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 137,
+        "endLineNumber": 139,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "attachment"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment"
+        ],
+        "returnType": "Promise<Buffer>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "133604229c84ecae",
+        "signatureHash": "e2838b8510275006"
+      }
+    },
+    {
+      "id": "function:getAttachmentExtension:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "getAttachmentExtension",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 157,
+        "endLineNumber": 160,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "attachment"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "8996dd8b4f46ed4b",
+        "signatureHash": "b09f1724bf004117",
+        "calledBy": [
+          "function:isImageAttachment:src/helpers/attachment.ts",
+          "function:isVideoAttachment:src/helpers/attachment.ts",
+          "function:isAudioAttachment:src/helpers/attachment.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "function:isImageAttachment:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "isImageAttachment",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 177,
+        "endLineNumber": 180,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "attachment"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment"
+        ],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "aaf33d5870335bbd",
+        "signatureHash": "e48f8731b2e9996c"
+      }
+    },
+    {
+      "id": "function:isVideoAttachment:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "isVideoAttachment",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 188,
+        "endLineNumber": 191,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "attachment"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment"
+        ],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "05a646f2c0fcb317",
+        "signatureHash": "e48f8731b2e9996c"
+      }
+    },
+    {
+      "id": "function:isAudioAttachment:src/helpers/attachment.ts",
+      "type": "function",
+      "name": "isAudioAttachment",
+      "metadata": {
+        "filePath": "src/helpers/attachment.ts",
+        "lineNumber": 199,
+        "endLineNumber": 202,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "attachment"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/types/message\").Attachment"
+        ],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "dbb039966b88ed24",
+        "signatureHash": "e48f8731b2e9996c"
+      }
+    },
+    {
+      "id": "module:core:src/plugins/core.ts",
+      "type": "module",
+      "name": "core",
+      "metadata": {
+        "filePath": "src/plugins/core.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:definePlugin:src/plugins/core.ts",
+      "type": "function",
+      "name": "definePlugin",
+      "metadata": {
+        "filePath": "src/plugins/core.ts",
+        "lineNumber": 193,
+        "endLineNumber": 193,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "plugin"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/plugins/core\").Plugin"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/plugins/core\").Plugin",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 50,
+        "contentHash": "5e689e2b01672bf3",
+        "signatureHash": "9f2986e962cb21a1",
+        "calledBy": [
+          "function:loggerPlugin:src/plugins/logger.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "class:PluginManager:src/plugins/core.ts",
+      "type": "class",
+      "name": "PluginManager",
+      "metadata": {
+        "filePath": "src/plugins/core.ts",
+        "lineNumber": 67,
+        "endLineNumber": 188,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:PluginManager.use:src/plugins/core.ts",
+      "type": "function",
+      "name": "PluginManager.use",
+      "metadata": {
+        "filePath": "src/plugins/core.ts",
+        "lineNumber": 80,
+        "endLineNumber": 91,
+        "isAsync": false,
+        "parameters": [
+          "plugin"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/plugins/core\").Plugin"
+        ],
+        "returnType": "this",
+        "contentHash": "ec3d5517ddd49eba",
+        "signatureHash": "b3d8f09ae602dce6",
+        "className": "PluginManager",
+        "calledBy": [
+          "function:IMessageSDK.use:src/core/sdk.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:PluginManager.init:src/plugins/core.ts",
+      "type": "function",
+      "name": "PluginManager.init",
+      "metadata": {
+        "filePath": "src/plugins/core.ts",
+        "lineNumber": 97,
+        "endLineNumber": 100,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "a2635913d07e5821",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "PluginManager",
+        "calledBy": [
+          "function:IMessageSDK.ensurePluginsReady:src/core/sdk.ts"
+        ],
+        "impactScore": 8
+      }
+    },
+    {
+      "id": "function:PluginManager.destroy:src/plugins/core.ts",
+      "type": "function",
+      "name": "PluginManager.destroy",
+      "metadata": {
+        "filePath": "src/plugins/core.ts",
+        "lineNumber": 106,
+        "endLineNumber": 110,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "22bedb691aefe426",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "PluginManager"
+      }
+    },
+    {
+      "id": "function:PluginManager.callHookForAll:src/plugins/core.ts",
+      "type": "function",
+      "name": "PluginManager.callHookForAll",
+      "metadata": {
+        "filePath": "src/plugins/core.ts",
+        "lineNumber": 118,
+        "endLineNumber": 187,
+        "isAsync": true,
+        "parameters": [
+          "hookName",
+          "args"
+        ],
+        "parameterTypes": [
+          "K",
+          "Parameters<NonNullable<import(\"/Users/mason/Documents/imessage-kit/src/plugins/core\").PluginHooks[K]>>"
+        ],
+        "returnType": "Promise<{ plugin: string; error: Error; }[]>",
+        "contentHash": "65b6b64649e6505f",
+        "signatureHash": "d4bc483d5c527534",
+        "className": "PluginManager",
+        "calledBy": [
+          "function:PluginManager.init:src/plugins/core.ts",
+          "function:PluginManager.destroy:src/plugins/core.ts"
+        ],
+        "impactScore": 10
+      }
+    },
+    {
+      "id": "module:index:src/plugins/index.ts",
+      "type": "module",
+      "name": "index",
+      "metadata": {
+        "filePath": "src/plugins/index.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:logger:src/plugins/logger.ts",
+      "type": "module",
+      "name": "logger",
+      "metadata": {
+        "filePath": "src/plugins/logger.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:loggerPlugin:src/plugins/logger.ts",
+      "type": "function",
+      "name": "loggerPlugin",
+      "metadata": {
+        "filePath": "src/plugins/logger.ts",
+        "lineNumber": 84,
+        "endLineNumber": 146,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "options"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/plugins/logger\").LoggerOptions"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/plugins/core\").Plugin",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "8cc1bc6c7a302b14",
+        "signatureHash": "8e68f45cc28dfc1c"
+      }
+    },
+    {
+      "id": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "type": "function",
+      "name": "loggerPlugin.log",
+      "metadata": {
+        "filePath": "src/plugins/logger.ts",
+        "lineNumber": 87,
+        "endLineNumber": 100,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "logLevel",
+          "message",
+          "data"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/plugins/logger\").LogLevel",
+          "string",
+          "unknown"
+        ],
+        "returnType": "void",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": false,
+        "missingTypeParams": [],
+        "weakTypeParams": [
+          "data"
+        ],
+        "typeCoveragePercent": 50,
+        "contentHash": "cc32abdcd982e47d",
+        "signatureHash": "78c9e981ddc9777d",
+        "calledBy": [
+          "function:scheduler:demo.ts",
+          "function:countdown:demo.ts",
+          "function:myPlugin:examples/11-plugin.ts",
+          "function:scheduler:examples/14-scheduled-messages.ts",
+          "function:reminders:examples/15-smart-reminders.ts",
+          "function:MessagePromise.matches:src/core/message-promise.ts",
+          "function:OutgoingMessageManager.add:src/core/outgoing-manager.ts",
+          "function:OutgoingMessageManager.tryResolve:src/core/outgoing-manager.ts",
+          "function:MessageSender.resolveAttachment:src/core/sender.ts",
+          "function:MessageSender.send.task:src/core/sender.ts",
+          "function:MessageSender.prepareAttachments:src/core/sender.ts",
+          "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+          "function:MessageWatcher.start:src/core/watcher.ts",
+          "function:MessageWatcher.stop:src/core/watcher.ts",
+          "function:MessageWatcher.check:src/core/watcher.ts",
+          "function:loggerPlugin:src/plugins/logger.ts",
+          "function:execAppleScript:src/utils/applescript.ts",
+          "function:checkIMessageStatus:src/utils/applescript.ts",
+          "function:generateSendAttachmentScript:src/utils/applescript.ts",
+          "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+          "function:downloadImage:src/utils/download.ts",
+          "function:MessageScheduler.schedule:src/utils/scheduler.ts",
+          "function:MessageScheduler.scheduleRecurring:src/utils/scheduler.ts",
+          "function:MessageScheduler.cancel:src/utils/scheduler.ts",
+          "function:MessageScheduler.reschedule:src/utils/scheduler.ts",
+          "function:MessageScheduler.import:src/utils/scheduler.ts",
+          "function:MessageScheduler.start:src/utils/scheduler.ts",
+          "function:MessageScheduler.tick:src/utils/scheduler.ts",
+          "function:MessageScheduler.sendMessage:src/utils/scheduler.ts",
+          "function:MessageScheduler.sendRecurringMessage:src/utils/scheduler.ts",
+          "function:MessageScheduler.destroy:src/utils/scheduler.ts",
+          "function:TempFileManager.start:src/utils/temp-file-manager.ts",
+          "function:TempFileManager.cleanup:src/utils/temp-file-manager.ts",
+          "function:TempFileManager.cleanupAll:src/utils/temp-file-manager.ts",
+          "function:TempFileManager.destroy:src/utils/temp-file-manager.ts"
+        ],
+        "impactScore": 65
+      }
+    },
+    {
+      "id": "module:advanced:src/types/advanced.ts",
+      "type": "module",
+      "name": "advanced",
+      "metadata": {
+        "filePath": "src/types/advanced.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:hasMinDigits:src/types/advanced.ts",
+      "type": "function",
+      "name": "hasMinDigits",
+      "metadata": {
+        "filePath": "src/types/advanced.ts",
+        "lineNumber": 17,
+        "endLineNumber": 20,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "str",
+          "min"
+        ],
+        "parameterTypes": [
+          "string",
+          "number"
+        ],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "808eb22b73ef67a8",
+        "signatureHash": "4f68c63288487449",
+        "calledBy": [
+          "function:asRecipient:src/types/advanced.ts"
+        ],
+        "impactScore": 13
+      }
+    },
+    {
+      "id": "function:asRecipient:src/types/advanced.ts",
+      "type": "function",
+      "name": "asRecipient",
+      "metadata": {
+        "filePath": "src/types/advanced.ts",
+        "lineNumber": 56,
+        "endLineNumber": 75,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "value"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "fdad27569aca317d",
+        "signatureHash": "0669b08db84fb7af",
+        "calledBy": [
+          "function:IMessageSDK.isChatId:src/core/sdk.ts",
+          "function:IMessageSDK.send:src/core/sdk.ts",
+          "function:MessageSender.send.task:src/core/sender.ts",
+          "function:MessageChain.replyText:src/core/chain.ts",
+          "function:MessageChain.replyImage:src/core/chain.ts"
+        ],
+        "impactScore": 12
+      }
+    },
+    {
+      "id": "function:isURL:src/types/advanced.ts",
+      "type": "function",
+      "name": "isURL",
+      "metadata": {
+        "filePath": "src/types/advanced.ts",
+        "lineNumber": 83,
+        "endLineNumber": 85,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "value"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "8b6540b81935c3d2",
+        "signatureHash": "b59f71b28547d043",
+        "calledBy": [
+          "function:MessageSender.resolveAttachment:src/core/sender.ts"
+        ],
+        "impactScore": 11
+      }
+    },
+    {
+      "id": "module:config:src/types/config.ts",
+      "type": "module",
+      "name": "config",
+      "metadata": {
+        "filePath": "src/types/config.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:message:src/types/message.ts",
+      "type": "module",
+      "name": "message",
+      "metadata": {
+        "filePath": "src/types/message.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "module:applescript:src/utils/applescript.ts",
+      "type": "module",
+      "name": "applescript",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:needsSandboxBypass:src/utils/applescript.ts",
+      "type": "function",
+      "name": "needsSandboxBypass",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 221,
+        "endLineNumber": 223,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "6e4695792136af46",
+        "signatureHash": "ea8b3b73e5eb8d79",
+        "calledBy": [
+          "function:generateSendAttachmentScript:src/utils/applescript.ts",
+          "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+          "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+          "function:generateSendWithAttachmentToChat:src/utils/applescript.ts"
+        ],
+        "impactScore": 17
+      }
+    },
+    {
+      "id": "function:buildTempFilenameTemplate:src/utils/applescript.ts",
+      "type": "function",
+      "name": "buildTempFilenameTemplate",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 246,
+        "endLineNumber": 256,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "2769a8e27307b19a",
+        "signatureHash": "0b2ca1ed00444787",
+        "calledBy": [
+          "function:generateSandboxBypassScript:src/utils/applescript.ts",
+          "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts"
+        ],
+        "impactScore": 19
+      }
+    },
+    {
+      "id": "function:calculateFileDelay:src/utils/applescript.ts",
+      "type": "function",
+      "name": "calculateFileDelay",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 262,
+        "endLineNumber": 274,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "number",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "a54f2d8196ba2541",
+        "signatureHash": "363932015865ca2a",
+        "calledBy": [
+          "function:generateSandboxBypassScript:src/utils/applescript.ts",
+          "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+          "function:generateDirectSendScript:src/utils/applescript.ts",
+          "function:generateDirectSendScriptForChat:src/utils/applescript.ts"
+        ],
+        "impactScore": 25
+      }
+    },
+    {
+      "id": "function:generateSandboxBypassScript:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateSandboxBypassScript",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 283,
+        "endLineNumber": 299,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "3fa5a37f09ab112d",
+        "signatureHash": "0b2ca1ed00444787",
+        "calledBy": [
+          "function:generateSendAttachmentScript:src/utils/applescript.ts",
+          "function:generateSendWithAttachmentScript:src/utils/applescript.ts"
+        ],
+        "impactScore": 12
+      }
+    },
+    {
+      "id": "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateSandboxBypassScriptForChat",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 305,
+        "endLineNumber": 321,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "d8c5cd8a2cec6f86",
+        "signatureHash": "0b2ca1ed00444787",
+        "calledBy": [
+          "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+          "function:generateSendWithAttachmentToChat:src/utils/applescript.ts"
+        ],
+        "impactScore": 5
+      }
+    },
+    {
+      "id": "function:generateDirectSendScript:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateDirectSendScript",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 326,
+        "endLineNumber": 333,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "e489721c7af3255e",
+        "signatureHash": "0b2ca1ed00444787",
+        "calledBy": [
+          "function:generateSendAttachmentScript:src/utils/applescript.ts",
+          "function:generateSendWithAttachmentScript:src/utils/applescript.ts"
+        ],
+        "impactScore": 12
+      }
+    },
+    {
+      "id": "function:generateDirectSendScriptForChat:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateDirectSendScriptForChat",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 338,
+        "endLineNumber": 345,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "a35cd6f0e1d3bdc3",
+        "signatureHash": "0b2ca1ed00444787",
+        "calledBy": [
+          "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+          "function:generateSendWithAttachmentToChat:src/utils/applescript.ts"
+        ],
+        "impactScore": 5
+      }
+    },
+    {
+      "id": "function:execAppleScript:src/utils/applescript.ts",
+      "type": "function",
+      "name": "execAppleScript",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 29,
+        "endLineNumber": 84,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "script",
+          "debug",
+          "timeoutMs"
+        ],
+        "parameterTypes": [
+          "string",
+          "boolean",
+          "number"
+        ],
+        "returnType": "Promise<string>",
+        "hasExplicitInputTypes": false,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [
+          "debug",
+          "timeoutMs"
+        ],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 50,
+        "contentHash": "33fe5d33f2115589",
+        "signatureHash": "cecf717da6db0708",
+        "calledBy": [
+          "function:MessageSender.executeWithRetry:src/core/sender.ts"
+        ],
+        "impactScore": 12
+      }
+    },
+    {
+      "id": "function:checkMessagesApp:src/utils/applescript.ts",
+      "type": "function",
+      "name": "checkMessagesApp",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 93,
+        "endLineNumber": 102,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<boolean>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "2b25ce579eff0665",
+        "signatureHash": "25a3b4f9c0f8f4a5",
+        "calledBy": [
+          "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts"
+        ],
+        "impactScore": 10
+      }
+    },
+    {
+      "id": "function:checkIMessageStatus:src/utils/applescript.ts",
+      "type": "function",
+      "name": "checkIMessageStatus",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 110,
+        "endLineNumber": 156,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "debug"
+        ],
+        "parameterTypes": [
+          "boolean"
+        ],
+        "returnType": "Promise<boolean>",
+        "hasExplicitInputTypes": false,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [
+          "debug"
+        ],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 50,
+        "contentHash": "758ad490d483a1a9",
+        "signatureHash": "feaf06cc766e6573",
+        "calledBy": [
+          "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts"
+        ],
+        "impactScore": 10
+      }
+    },
+    {
+      "id": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "type": "function",
+      "name": "escapeAppleScriptString",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 166,
+        "endLineNumber": 177,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "str"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "a28952e91a11c0be",
+        "signatureHash": "1113ef23dcdcf1d8",
+        "calledBy": [
+          "function:generateSendTextScript:src/utils/applescript.ts",
+          "function:generateSendTextToChat:src/utils/applescript.ts",
+          "function:generateSandboxBypassScript:src/utils/applescript.ts",
+          "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+          "function:generateDirectSendScript:src/utils/applescript.ts",
+          "function:generateDirectSendScriptForChat:src/utils/applescript.ts",
+          "function:generateSendAttachmentScript:src/utils/applescript.ts",
+          "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+          "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+          "function:generateSendWithAttachmentToChat:src/utils/applescript.ts"
+        ],
+        "impactScore": 33
+      }
+    },
+    {
+      "id": "function:generateSendTextScript:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateSendTextScript",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 186,
+        "endLineNumber": 197,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "recipient",
+          "text"
+        ],
+        "parameterTypes": [
+          "string",
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "dd7f181e5583db91",
+        "signatureHash": "c50adbc5aabc8a2b",
+        "calledBy": [
+          "function:MessageSender.sendToRecipient:src/core/sender.ts"
+        ],
+        "impactScore": 9
+      }
+    },
+    {
+      "id": "function:generateSendTextToChat:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateSendTextToChat",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 206,
+        "endLineNumber": 216,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "chatId",
+          "text"
+        ],
+        "parameterTypes": [
+          "string",
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "cfa458a45f13730e",
+        "signatureHash": "d84a1dadb99433a0",
+        "calledBy": [
+          "function:MessageSender.sendToGroupChat:src/core/sender.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:generateSendAttachmentScript:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateSendAttachmentScript",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 355,
+        "endLineNumber": 379,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "recipient",
+          "filePath",
+          "debug"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "boolean"
+        ],
+        "returnType": "{ script: string; }",
+        "hasExplicitInputTypes": false,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [
+          "debug"
+        ],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 75,
+        "contentHash": "97eff260fc775492",
+        "signatureHash": "5caa5211313dfceb",
+        "calledBy": [
+          "function:MessageSender.sendToRecipient:src/core/sender.ts"
+        ],
+        "impactScore": 9
+      }
+    },
+    {
+      "id": "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateSendAttachmentToChat",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 384,
+        "endLineNumber": 405,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "chatId",
+          "filePath",
+          "debug"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "boolean"
+        ],
+        "returnType": "{ script: string; }",
+        "hasExplicitInputTypes": false,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [
+          "debug"
+        ],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 75,
+        "contentHash": "b16cb0df9ecc6390",
+        "signatureHash": "48073d586cd151a8",
+        "calledBy": [
+          "function:MessageSender.sendToGroupChat:src/core/sender.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateSendWithAttachmentScript",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 417,
+        "endLineNumber": 442,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "recipient",
+          "text",
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "string"
+        ],
+        "returnType": "{ script: string; }",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "11bfb29c40689071",
+        "signatureHash": "02210623bffe68a4",
+        "calledBy": [
+          "function:MessageSender.sendToRecipient:src/core/sender.ts"
+        ],
+        "impactScore": 9
+      }
+    },
+    {
+      "id": "function:generateSendWithAttachmentToChat:src/utils/applescript.ts",
+      "type": "function",
+      "name": "generateSendWithAttachmentToChat",
+      "metadata": {
+        "filePath": "src/utils/applescript.ts",
+        "lineNumber": 447,
+        "endLineNumber": 473,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "chatId",
+          "text",
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "string"
+        ],
+        "returnType": "{ script: string; }",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "cbe950f254144c05",
+        "signatureHash": "10e6af2a420cedd3",
+        "calledBy": [
+          "function:MessageSender.sendToGroupChat:src/core/sender.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "module:common:src/utils/common.ts",
+      "type": "module",
+      "name": "common",
+      "metadata": {
+        "filePath": "src/utils/common.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:validateMessageContent:src/utils/common.ts",
+      "type": "function",
+      "name": "validateMessageContent",
+      "metadata": {
+        "filePath": "src/utils/common.ts",
+        "lineNumber": 20,
+        "endLineNumber": 32,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "text",
+          "attachments"
+        ],
+        "parameterTypes": [
+          "string",
+          "readonly string[]"
+        ],
+        "returnType": "{ hasText: boolean; hasAttachments: boolean; }",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "1f4baef2b7b01dbf",
+        "signatureHash": "48fa9deef8fe9f44",
+        "calledBy": [
+          "function:MessageSender.send.task:src/core/sender.ts",
+          "function:MessageSender.sendToGroup.task:src/core/sender.ts"
+        ],
+        "impactScore": 9
+      }
+    },
+    {
+      "id": "function:normalizeChatId:src/utils/common.ts",
+      "type": "function",
+      "name": "normalizeChatId",
+      "metadata": {
+        "filePath": "src/utils/common.ts",
+        "lineNumber": 41,
+        "endLineNumber": 53,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "chatId"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "cb10f547a650295a",
+        "signatureHash": "4e734c0ad4105a85",
+        "calledBy": [
+          "function:MessagePromise.normalizeChatId:src/core/message-promise.ts"
+        ],
+        "impactScore": 4
+      }
+    },
+    {
+      "id": "function:isGroupChatId:src/utils/common.ts",
+      "type": "function",
+      "name": "isGroupChatId",
+      "metadata": {
+        "filePath": "src/utils/common.ts",
+        "lineNumber": 61,
+        "endLineNumber": 73,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "chatId"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "d1cf97f2dfa98451",
+        "signatureHash": "4aaac0c21cd7e490",
+        "calledBy": [
+          "function:IMessageSDK.isChatId:src/core/sdk.ts",
+          "function:extractRecipientFromChatId:src/utils/common.ts",
+          "function:MessageChain.replyText:src/core/chain.ts",
+          "function:MessageChain.replyImage:src/core/chain.ts"
+        ],
+        "impactScore": 11
+      }
+    },
+    {
+      "id": "function:extractRecipientFromChatId:src/utils/common.ts",
+      "type": "function",
+      "name": "extractRecipientFromChatId",
+      "metadata": {
+        "filePath": "src/utils/common.ts",
+        "lineNumber": 81,
+        "endLineNumber": 98,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "chatId"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "d74bb25bf61e630d",
+        "signatureHash": "4e734c0ad4105a85",
+        "calledBy": [
+          "function:IMessageSDK.isChatId:src/core/sdk.ts",
+          "function:IMessageSDK.send:src/core/sdk.ts",
+          "function:MessageChain.replyText:src/core/chain.ts",
+          "function:MessageChain.replyImage:src/core/chain.ts"
+        ],
+        "impactScore": 8
+      }
+    },
+    {
+      "id": "function:validateChatId:src/utils/common.ts",
+      "type": "function",
+      "name": "validateChatId",
+      "metadata": {
+        "filePath": "src/utils/common.ts",
+        "lineNumber": 109,
+        "endLineNumber": 141,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "chatId"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "void",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "d5e2ff43008e0bff",
+        "signatureHash": "3a39313477a3cdf4",
+        "calledBy": [
+          "function:IMessageSDK.send:src/core/sdk.ts",
+          "function:MessageSender.sendToGroup.task:src/core/sender.ts"
+        ],
+        "impactScore": 5
+      }
+    },
+    {
+      "id": "function:delay:src/utils/common.ts",
+      "type": "function",
+      "name": "delay",
+      "metadata": {
+        "filePath": "src/utils/common.ts",
+        "lineNumber": 9,
+        "endLineNumber": 11,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [
+          "ms"
+        ],
+        "parameterTypes": [
+          "number"
+        ],
+        "returnType": "Promise<void>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "244656bb6a7f8942",
+        "signatureHash": "b365cfa3b30c7aa1",
+        "calledBy": [
+          "function:MessageSender.executeWithRetry:src/core/sender.ts",
+          "function:MessageSender.sendToRecipient:src/core/sender.ts",
+          "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+          "function:downloadImage:src/utils/download.ts"
+        ],
+        "impactScore": 17
+      }
+    },
+    {
+      "id": "module:download:src/utils/download.ts",
+      "type": "module",
+      "name": "download",
+      "metadata": {
+        "filePath": "src/utils/download.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:generateSecureFilename:src/utils/download.ts",
+      "type": "function",
+      "name": "generateSecureFilename",
+      "metadata": {
+        "filePath": "src/utils/download.ts",
+        "lineNumber": 20,
+        "endLineNumber": 22,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "ext"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "ba1fc90d3cd0379a",
+        "signatureHash": "80f48ccbca920581",
+        "calledBy": [
+          "function:convertImageToJPEG:src/utils/download.ts",
+          "function:downloadImage:src/utils/download.ts",
+          "function:convertToCompatibleFormat:src/utils/download.ts"
+        ],
+        "impactScore": 17
+      }
+    },
+    {
+      "id": "function:convertImageToJPEG:src/utils/download.ts",
+      "type": "function",
+      "name": "convertImageToJPEG",
+      "metadata": {
+        "filePath": "src/utils/download.ts",
+        "lineNumber": 32,
+        "endLineNumber": 48,
+        "isAsync": true,
+        "isExported": false,
+        "parameters": [
+          "inputPath",
+          "outputPath"
+        ],
+        "parameterTypes": [
+          "string",
+          "string"
+        ],
+        "returnType": "Promise<string>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "4b16b958768f06ad",
+        "signatureHash": "412fe4bccf21a855",
+        "calledBy": [
+          "function:downloadImage:src/utils/download.ts",
+          "function:convertToCompatibleFormat:src/utils/download.ts"
+        ],
+        "impactScore": 14
+      }
+    },
+    {
+      "id": "function:downloadImage:src/utils/download.ts",
+      "type": "function",
+      "name": "downloadImage",
+      "metadata": {
+        "filePath": "src/utils/download.ts",
+        "lineNumber": 54,
+        "endLineNumber": 133,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "url",
+          "options"
+        ],
+        "parameterTypes": [
+          "string",
+          "DownloadOptions"
+        ],
+        "returnType": "Promise<string>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "82457ad7a044ddf7",
+        "signatureHash": "8b4108453b50c51c",
+        "calledBy": [
+          "function:MessageSender.resolveAttachment:src/core/sender.ts"
+        ],
+        "impactScore": 11
+      }
+    },
+    {
+      "id": "function:convertToCompatibleFormat:src/utils/download.ts",
+      "type": "function",
+      "name": "convertToCompatibleFormat",
+      "metadata": {
+        "filePath": "src/utils/download.ts",
+        "lineNumber": 139,
+        "endLineNumber": 155,
+        "isAsync": true,
+        "isExported": true,
+        "parameters": [
+          "filePath"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "Promise<{ path: string; converted: boolean; }>",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "c6645e04727fd9e6",
+        "signatureHash": "78bbe10d8b96c59f",
+        "calledBy": [
+          "function:MessageSender.resolveAttachment:src/core/sender.ts"
+        ],
+        "impactScore": 11
+      }
+    },
+    {
+      "id": "module:platform:src/utils/platform.ts",
+      "type": "module",
+      "name": "platform",
+      "metadata": {
+        "filePath": "src/utils/platform.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:requireMacOS:src/utils/platform.ts",
+      "type": "function",
+      "name": "requireMacOS",
+      "metadata": {
+        "filePath": "src/utils/platform.ts",
+        "lineNumber": 14,
+        "endLineNumber": 18,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "2f83dcbd635f463a",
+        "signatureHash": "0f873ee2af8f6018"
+      }
+    },
+    {
+      "id": "function:isMacOS:src/utils/platform.ts",
+      "type": "function",
+      "name": "isMacOS",
+      "metadata": {
+        "filePath": "src/utils/platform.ts",
+        "lineNumber": 25,
+        "endLineNumber": 27,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "boolean",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "3b2438a0388883a4",
+        "signatureHash": "14bebcdadef0d085"
+      }
+    },
+    {
+      "id": "function:getDefaultDatabasePath:src/utils/platform.ts",
+      "type": "function",
+      "name": "getDefaultDatabasePath",
+      "metadata": {
+        "filePath": "src/utils/platform.ts",
+        "lineNumber": 35,
+        "endLineNumber": 43,
+        "isAsync": false,
+        "isExported": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "6f1b2ccc3bf7b4cf",
+        "signatureHash": "b4d08d51abdf2754",
+        "calledBy": [
+          "function:IMessageSDK.resolveConfig:src/core/sdk.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "module:reminders:src/utils/reminders.ts",
+      "type": "module",
+      "name": "reminders",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:parseDuration:src/utils/reminders.ts",
+      "type": "function",
+      "name": "parseDuration",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 51,
+        "endLineNumber": 69,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "duration"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "number",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "4bacce7e8d7e19d9",
+        "signatureHash": "7e14730e965f50d7",
+        "calledBy": [
+          "function:Reminders.in:src/utils/reminders.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:parseTime:src/utils/reminders.ts",
+      "type": "function",
+      "name": "parseTime",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 74,
+        "endLineNumber": 112,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "timeStr"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "{ hours: number; minutes: number; }",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "42e93cddaba510ea",
+        "signatureHash": "429c2d5e124e9f47",
+        "calledBy": [
+          "function:parseAtExpression:src/utils/reminders.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:parseAtExpression:src/utils/reminders.ts",
+      "type": "function",
+      "name": "parseAtExpression",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 117,
+        "endLineNumber": 153,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "expression"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "Date",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "d9e01978cfc9b4df",
+        "signatureHash": "2161dafac9144aee",
+        "calledBy": [
+          "function:Reminders.at:src/utils/reminders.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "class:Reminders:src/utils/reminders.ts",
+      "type": "class",
+      "name": "Reminders",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 158,
+        "endLineNumber": 302,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:Reminders.in:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.in",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 199,
+        "endLineNumber": 203,
+        "isAsync": false,
+        "parameters": [
+          "duration",
+          "to",
+          "message",
+          "options"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "string",
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/reminders\").ReminderOptions"
+        ],
+        "returnType": "string",
+        "contentHash": "0b2a09e642bf0c3f",
+        "signatureHash": "c10802dc2be2bff0",
+        "className": "Reminders"
+      }
+    },
+    {
+      "id": "function:Reminders.at:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.at",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 215,
+        "endLineNumber": 218,
+        "isAsync": false,
+        "parameters": [
+          "timeExpression",
+          "to",
+          "message",
+          "options"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "string",
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/reminders\").ReminderOptions"
+        ],
+        "returnType": "string",
+        "contentHash": "5baa356b0a98ff94",
+        "signatureHash": "d75431bf160ddf35",
+        "className": "Reminders"
+      }
+    },
+    {
+      "id": "function:Reminders.exact:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.exact",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 223,
+        "endLineNumber": 225,
+        "isAsync": false,
+        "parameters": [
+          "date",
+          "to",
+          "message",
+          "options"
+        ],
+        "parameterTypes": [
+          "Date",
+          "string",
+          "string",
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/reminders\").ReminderOptions"
+        ],
+        "returnType": "string",
+        "contentHash": "afa7e4205c9601cd",
+        "signatureHash": "64576b4aa0a85035",
+        "className": "Reminders"
+      }
+    },
+    {
+      "id": "function:Reminders.scheduleReminder:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.scheduleReminder",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 227,
+        "endLineNumber": 247,
+        "isAsync": false,
+        "parameters": [
+          "to",
+          "message",
+          "sendAt",
+          "options"
+        ],
+        "parameterTypes": [
+          "string",
+          "string",
+          "Date",
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/reminders\").ReminderOptions"
+        ],
+        "returnType": "string",
+        "contentHash": "4f93751e77a55533",
+        "signatureHash": "173e1697c0b86a74",
+        "className": "Reminders",
+        "calledBy": [
+          "function:Reminders.in:src/utils/reminders.ts",
+          "function:Reminders.at:src/utils/reminders.ts",
+          "function:Reminders.exact:src/utils/reminders.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "function:Reminders.cancel:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.cancel",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 252,
+        "endLineNumber": 258,
+        "isAsync": false,
+        "parameters": [
+          "id"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "boolean",
+        "contentHash": "cb558e2ae5aaad9a",
+        "signatureHash": "70fd422a6f9fd813",
+        "className": "Reminders"
+      }
+    },
+    {
+      "id": "function:Reminders.get:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.get",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 263,
+        "endLineNumber": 271,
+        "isAsync": false,
+        "parameters": [
+          "id"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/utils/reminders\").Reminder",
+        "contentHash": "f03792edd0303e9d",
+        "signatureHash": "115454104c1e6a18",
+        "className": "Reminders",
+        "calledBy": [
+          "function:insertTestMessage:__tests__/setup.ts",
+          "function:IMessageDatabase.getUnreadMessages:src/core/database.ts",
+          "function:downloadImage:src/utils/download.ts",
+          "function:Reminders.count:src/utils/reminders.ts"
+        ],
+        "impactScore": 15
+      }
+    },
+    {
+      "id": "function:Reminders.list:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.list",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 276,
+        "endLineNumber": 280,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/utils/reminders\").Reminder[]",
+        "contentHash": "7c6ef8208e7b8758",
+        "signatureHash": "3c41a030f479a7d0",
+        "className": "Reminders"
+      }
+    },
+    {
+      "id": "function:Reminders.count:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.count",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 285,
+        "endLineNumber": 293,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "number",
+        "contentHash": "6a2ec79ecf24d8d0",
+        "signatureHash": "f4b49792b0071f74",
+        "className": "Reminders"
+      }
+    },
+    {
+      "id": "function:Reminders.destroy:src/utils/reminders.ts",
+      "type": "function",
+      "name": "Reminders.destroy",
+      "metadata": {
+        "filePath": "src/utils/reminders.ts",
+        "lineNumber": 298,
+        "endLineNumber": 301,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "56b34f3325dad03c",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "Reminders"
+      }
+    },
+    {
+      "id": "module:scheduler:src/utils/scheduler.ts",
+      "type": "module",
+      "name": "scheduler",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "function:generateId:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "generateId",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 131,
+        "endLineNumber": 133,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "string",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "eca3e88e530d886b",
+        "signatureHash": "b4d08d51abdf2754",
+        "calledBy": [
+          "function:MessageScheduler.schedule:src/utils/scheduler.ts",
+          "function:MessageScheduler.scheduleRecurring:src/utils/scheduler.ts"
+        ],
+        "impactScore": 6
+      }
+    },
+    {
+      "id": "function:calculateNextSendTime:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "calculateNextSendTime",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 138,
+        "endLineNumber": 161,
+        "isAsync": false,
+        "isExported": false,
+        "parameters": [
+          "current",
+          "interval"
+        ],
+        "parameterTypes": [
+          "Date",
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").RecurrenceInterval"
+        ],
+        "returnType": "Date",
+        "hasExplicitInputTypes": true,
+        "hasExplicitOutputType": true,
+        "missingTypeParams": [],
+        "weakTypeParams": [],
+        "typeCoveragePercent": 100,
+        "contentHash": "f1342ad9f7fc4d41",
+        "signatureHash": "7aabf5d5c0dd5e17",
+        "calledBy": [
+          "function:MessageScheduler.tick:src/utils/scheduler.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "class:MessageScheduler:src/utils/scheduler.ts",
+      "type": "class",
+      "name": "MessageScheduler",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 168,
+        "endLineNumber": 598,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:MessageScheduler.schedule:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.schedule",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 196,
+        "endLineNumber": 229,
+        "isAsync": false,
+        "parameters": [
+          "options"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").ScheduleOptions"
+        ],
+        "returnType": "string",
+        "contentHash": "f2b4c283b0f557b8",
+        "signatureHash": "7e196b3c46850358",
+        "className": "MessageScheduler",
+        "calledBy": [
+          "function:Reminders.scheduleReminder:src/utils/reminders.ts"
+        ],
+        "impactScore": 4
+      }
+    },
+    {
+      "id": "function:MessageScheduler.scheduleRecurring:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.scheduleRecurring",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 236,
+        "endLineNumber": 279,
+        "isAsync": false,
+        "parameters": [
+          "options"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").RecurringScheduleOptions"
+        ],
+        "returnType": "string",
+        "contentHash": "cbae10da8f2c2f33",
+        "signatureHash": "7a959cf98ee3e9d1",
+        "className": "MessageScheduler"
+      }
+    },
+    {
+      "id": "function:MessageScheduler.cancel:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.cancel",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 286,
+        "endLineNumber": 308,
+        "isAsync": false,
+        "parameters": [
+          "id"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "boolean",
+        "contentHash": "be64f5932af93b47",
+        "signatureHash": "70fd422a6f9fd813",
+        "className": "MessageScheduler",
+        "calledBy": [
+          "function:Reminders.cancel:src/utils/reminders.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:MessageScheduler.reschedule:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.reschedule",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 315,
+        "endLineNumber": 337,
+        "isAsync": false,
+        "parameters": [
+          "id",
+          "newSendAt"
+        ],
+        "parameterTypes": [
+          "string",
+          "Date"
+        ],
+        "returnType": "boolean",
+        "contentHash": "f66355a0a3572b20",
+        "signatureHash": "f97f98137fc2194c",
+        "className": "MessageScheduler"
+      }
+    },
+    {
+      "id": "function:MessageScheduler.get:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.get",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 342,
+        "endLineNumber": 344,
+        "isAsync": false,
+        "parameters": [
+          "id"
+        ],
+        "parameterTypes": [
+          "string"
+        ],
+        "returnType": "import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").ScheduledMessage | import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").RecurringMessage",
+        "contentHash": "72047e8a5ebd9729",
+        "signatureHash": "35c73e2f5390d5d4",
+        "className": "MessageScheduler",
+        "calledBy": [
+          "function:MessageScheduler.cancel:src/utils/scheduler.ts",
+          "function:MessageScheduler.reschedule:src/utils/scheduler.ts",
+          "function:Reminders.get:src/utils/reminders.ts",
+          "function:Reminders.list:src/utils/reminders.ts"
+        ],
+        "impactScore": 20
+      }
+    },
+    {
+      "id": "function:MessageScheduler.getPending:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.getPending",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 349,
+        "endLineNumber": 369,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "(import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").ScheduledMessage | import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").RecurringMessage)[]",
+        "contentHash": "c21e78e886a48a95",
+        "signatureHash": "78faee0e6fc83f42",
+        "className": "MessageScheduler"
+      }
+    },
+    {
+      "id": "function:MessageScheduler.export:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.export",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 374,
+        "endLineNumber": 382,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "{ scheduled: import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").ScheduledMessage[]; recurring: import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").RecurringMessage[]; }",
+        "contentHash": "4cbe62472ff9e35f",
+        "signatureHash": "4a46bba082783a0a",
+        "className": "MessageScheduler"
+      }
+    },
+    {
+      "id": "function:MessageScheduler.import:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.import",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 388,
+        "endLineNumber": 434,
+        "isAsync": false,
+        "parameters": [
+          "data"
+        ],
+        "parameterTypes": [
+          "{ scheduled?: import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").ScheduledMessage[]; recurring?: import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").RecurringMessage[]; }"
+        ],
+        "returnType": "{ imported: number; skipped: number; }",
+        "contentHash": "cf83f058d23ba010",
+        "signatureHash": "ce4506b260c87436",
+        "className": "MessageScheduler"
+      }
+    },
+    {
+      "id": "function:MessageScheduler.start:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.start",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 439,
+        "endLineNumber": 451,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "57cc784770f87c06",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "MessageScheduler"
+      }
+    },
+    {
+      "id": "function:MessageScheduler.tick:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.tick",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 456,
+        "endLineNumber": 507,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "6457a4d2fdbc21cc",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "MessageScheduler"
+      }
+    },
+    {
+      "id": "function:MessageScheduler.sendMessage:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.sendMessage",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 512,
+        "endLineNumber": 536,
+        "isAsync": true,
+        "parameters": [
+          "msg"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").ScheduledMessage"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "15b59323118045f9",
+        "signatureHash": "f88a844bd316f07a",
+        "className": "MessageScheduler",
+        "calledBy": [
+          "function:MessageScheduler.tick:src/utils/scheduler.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:MessageScheduler.sendRecurringMessage:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.sendRecurringMessage",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 541,
+        "endLineNumber": 564,
+        "isAsync": true,
+        "parameters": [
+          "msg"
+        ],
+        "parameterTypes": [
+          "import(\"/Users/mason/Documents/imessage-kit/src/utils/scheduler\").RecurringMessage"
+        ],
+        "returnType": "Promise<void>",
+        "contentHash": "a6218d27283af61d",
+        "signatureHash": "c6a414b05fd8b7d1",
+        "className": "MessageScheduler",
+        "calledBy": [
+          "function:MessageScheduler.tick:src/utils/scheduler.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "function:MessageScheduler.destroy:src/utils/scheduler.ts",
+      "type": "function",
+      "name": "MessageScheduler.destroy",
+      "metadata": {
+        "filePath": "src/utils/scheduler.ts",
+        "lineNumber": 569,
+        "endLineNumber": 597,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "e33da8da65462b58",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "MessageScheduler"
+      }
+    },
+    {
+      "id": "module:semaphore:src/utils/semaphore.ts",
+      "type": "module",
+      "name": "semaphore",
+      "metadata": {
+        "filePath": "src/utils/semaphore.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "class:Semaphore:src/utils/semaphore.ts",
+      "type": "class",
+      "name": "Semaphore",
+      "metadata": {
+        "filePath": "src/utils/semaphore.ts",
+        "lineNumber": 4,
+        "endLineNumber": 49,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:Semaphore.acquire:src/utils/semaphore.ts",
+      "type": "function",
+      "name": "Semaphore.acquire",
+      "metadata": {
+        "filePath": "src/utils/semaphore.ts",
+        "lineNumber": 19,
+        "endLineNumber": 33,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<() => void>",
+        "contentHash": "89c6964c951a3b6a",
+        "signatureHash": "8ea4b2f37586d63b",
+        "className": "Semaphore",
+        "calledBy": [
+          "function:task:__tests__/02-utils.test.ts",
+          "function:Semaphore.run:src/utils/semaphore.ts"
+        ],
+        "impactScore": 3
+      }
+    },
+    {
+      "id": "function:Semaphore.run:src/utils/semaphore.ts",
+      "type": "function",
+      "name": "Semaphore.run",
+      "metadata": {
+        "filePath": "src/utils/semaphore.ts",
+        "lineNumber": 41,
+        "endLineNumber": 48,
+        "isAsync": true,
+        "parameters": [
+          "fn"
+        ],
+        "parameterTypes": [
+          "() => Promise<T>"
+        ],
+        "returnType": "Promise<T>",
+        "contentHash": "bf6bb64fc4a06570",
+        "signatureHash": "c6e9ecd403f89ad9",
+        "className": "Semaphore",
+        "calledBy": [
+          "function:insertTestMessage:__tests__/setup.ts"
+        ],
+        "impactScore": 1
+      }
+    },
+    {
+      "id": "module:temp-file-manager:src/utils/temp-file-manager.ts",
+      "type": "module",
+      "name": "temp-file-manager",
+      "metadata": {
+        "filePath": "src/utils/temp-file-manager.ts",
+        "lineNumber": 1
+      }
+    },
+    {
+      "id": "class:TempFileManager:src/utils/temp-file-manager.ts",
+      "type": "class",
+      "name": "TempFileManager",
+      "metadata": {
+        "filePath": "src/utils/temp-file-manager.ts",
+        "lineNumber": 38,
+        "endLineNumber": 273,
+        "isExported": true
+      }
+    },
+    {
+      "id": "function:TempFileManager.start:src/utils/temp-file-manager.ts",
+      "type": "function",
+      "name": "TempFileManager.start",
+      "metadata": {
+        "filePath": "src/utils/temp-file-manager.ts",
+        "lineNumber": 54,
+        "endLineNumber": 85,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "8a3ff8493014d4d8",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "TempFileManager"
+      }
+    },
+    {
+      "id": "function:TempFileManager.cleanup:src/utils/temp-file-manager.ts",
+      "type": "function",
+      "name": "TempFileManager.cleanup",
+      "metadata": {
+        "filePath": "src/utils/temp-file-manager.ts",
+        "lineNumber": 93,
+        "endLineNumber": 155,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<{ removed: number; errors: number; }>",
+        "contentHash": "e4c5e4ceaadd142c",
+        "signatureHash": "9eb8b4c1aa1486c5",
+        "className": "TempFileManager",
+        "calledBy": [
+          "function:TempFileManager.start:src/utils/temp-file-manager.ts",
+          "function:OutgoingMessageManager.cleanup:src/core/outgoing-manager.ts"
+        ],
+        "impactScore": 2
+      }
+    },
+    {
+      "id": "function:TempFileManager.cleanupAll:src/utils/temp-file-manager.ts",
+      "type": "function",
+      "name": "TempFileManager.cleanupAll",
+      "metadata": {
+        "filePath": "src/utils/temp-file-manager.ts",
+        "lineNumber": 162,
+        "endLineNumber": 217,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<{ removed: number; errors: number; }>",
+        "contentHash": "7b9f3051c157a0c7",
+        "signatureHash": "9eb8b4c1aa1486c5",
+        "className": "TempFileManager",
+        "calledBy": [
+          "function:TempFileManager.destroy:src/utils/temp-file-manager.ts"
+        ],
+        "impactScore": 6
+      }
+    },
+    {
+      "id": "function:TempFileManager.stop:src/utils/temp-file-manager.ts",
+      "type": "function",
+      "name": "TempFileManager.stop",
+      "metadata": {
+        "filePath": "src/utils/temp-file-manager.ts",
+        "lineNumber": 222,
+        "endLineNumber": 227,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "void",
+        "contentHash": "1c6f7ee7c2550abf",
+        "signatureHash": "0f873ee2af8f6018",
+        "className": "TempFileManager",
+        "calledBy": [
+          "function:TempFileManager.destroy:src/utils/temp-file-manager.ts",
+          "function:IMessageSDK.stopWatching:src/core/sdk.ts",
+          "function:IMessageSDK.close:src/core/sdk.ts"
+        ],
+        "impactScore": 8
+      }
+    },
+    {
+      "id": "function:TempFileManager.destroy:src/utils/temp-file-manager.ts",
+      "type": "function",
+      "name": "TempFileManager.destroy",
+      "metadata": {
+        "filePath": "src/utils/temp-file-manager.ts",
+        "lineNumber": 232,
+        "endLineNumber": 246,
+        "isAsync": true,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "Promise<void>",
+        "contentHash": "ceb59c9cfa5b476a",
+        "signatureHash": "cc364fd235a461a0",
+        "className": "TempFileManager",
+        "calledBy": [
+          "function:Reminders.destroy:src/utils/reminders.ts",
+          "function:IMessageSDK.close:src/core/sdk.ts"
+        ],
+        "impactScore": 5
+      }
+    },
+    {
+      "id": "function:TempFileManager.getStats:src/utils/temp-file-manager.ts",
+      "type": "function",
+      "name": "TempFileManager.getStats",
+      "metadata": {
+        "filePath": "src/utils/temp-file-manager.ts",
+        "lineNumber": 251,
+        "endLineNumber": 272,
+        "isAsync": false,
+        "parameters": [],
+        "parameterTypes": [],
+        "returnType": "{ currentFiles: number; isRunning: boolean; config: Required<import(\"/Users/mason/Documents/imessage-kit/src/utils/temp-file-manager\").TempFileManagerConfig>; }",
+        "contentHash": "f3ede6b24577399e",
+        "signatureHash": "1bd7b2872e1f3a11",
+        "className": "TempFileManager"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "source": "module:demo:demo.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:01-errors.test:__tests__/01-errors.test.ts",
+      "target": "module:errors:src/core/errors.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:03-database.test:__tests__/03-database.test.ts",
+      "target": "module:database:src/core/database.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:03-database.test:__tests__/03-database.test.ts",
+      "target": "module:errors:src/core/errors.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:03-database.test:__tests__/03-database.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:04-plugins.test:__tests__/04-plugins.test.ts",
+      "target": "module:core:src/plugins/core.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:04-plugins.test:__tests__/04-plugins.test.ts",
+      "target": "module:logger:src/plugins/logger.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:04-plugins.test:__tests__/04-plugins.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:05-chain.test:__tests__/05-chain.test.ts",
+      "target": "module:chain:src/core/chain.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:05-chain.test:__tests__/05-chain.test.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:05-chain.test:__tests__/05-chain.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:06-sdk-core.test:__tests__/06-sdk-core.test.ts",
+      "target": "kafka-producer:_1234567890:__tests__/06-sdk-core.test.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:06-sdk-core.test:__tests__/06-sdk-core.test.ts",
+      "target": "module:database:src/core/database.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:06-sdk-core.test:__tests__/06-sdk-core.test.ts",
+      "target": "module:sdk:src/core/sdk.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:06-sdk-core.test:__tests__/06-sdk-core.test.ts",
+      "target": "module:sender:src/core/sender.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:06-sdk-core.test:__tests__/06-sdk-core.test.ts",
+      "target": "module:core:src/plugins/core.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:06-sdk-core.test:__tests__/06-sdk-core.test.ts",
+      "target": "module:advanced:src/types/advanced.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:06-sdk-core.test:__tests__/06-sdk-core.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:07-integration.test:__tests__/07-integration.test.ts",
+      "target": "module:database:src/core/database.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:07-integration.test:__tests__/07-integration.test.ts",
+      "target": "module:sdk:src/core/sdk.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:07-integration.test:__tests__/07-integration.test.ts",
+      "target": "module:sender:src/core/sender.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:07-integration.test:__tests__/07-integration.test.ts",
+      "target": "module:core:src/plugins/core.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:07-integration.test:__tests__/07-integration.test.ts",
+      "target": "module:logger:src/plugins/logger.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:07-integration.test:__tests__/07-integration.test.ts",
+      "target": "module:advanced:src/types/advanced.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:07-integration.test:__tests__/07-integration.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:08-listchats.test:__tests__/08-listchats.test.ts",
+      "target": "module:database:src/core/database.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:08-listchats.test:__tests__/08-listchats.test.ts",
+      "target": "module:sdk:src/core/sdk.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:08-listchats.test:__tests__/08-listchats.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:09-search-and-attachments.test:__tests__/09-search-and-attachments.test.ts",
+      "target": "module:database:src/core/database.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:09-search-and-attachments.test:__tests__/09-search-and-attachments.test.ts",
+      "target": "module:sdk:src/core/sdk.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:09-search-and-attachments.test:__tests__/09-search-and-attachments.test.ts",
+      "target": "module:attachment:src/helpers/attachment.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:09-search-and-attachments.test:__tests__/09-search-and-attachments.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:10-message-promise.test:__tests__/10-message-promise.test.ts",
+      "target": "module:message-promise:src/core/message-promise.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:10-message-promise.test:__tests__/10-message-promise.test.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:11-outgoing-manager.test:__tests__/11-outgoing-manager.test.ts",
+      "target": "module:message-promise:src/core/message-promise.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:11-outgoing-manager.test:__tests__/11-outgoing-manager.test.ts",
+      "target": "module:outgoing-manager:src/core/outgoing-manager.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:11-outgoing-manager.test:__tests__/11-outgoing-manager.test.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:12-attributed-body.test:__tests__/12-attributed-body.test.ts",
+      "target": "function:extractTextFromAttributedBody:__tests__/12-attributed-body.test.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:12-scheduler.test:__tests__/12-scheduler.test.ts",
+      "target": "function:createMockSDK:__tests__/12-scheduler.test.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "function:createMockSDK:__tests__/12-scheduler.test.ts",
+      "target": "function:createMockSDK.defaultSend:__tests__/12-scheduler.test.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:12-scheduler.test:__tests__/12-scheduler.test.ts",
+      "target": "module:sdk:src/core/sdk.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:12-scheduler.test:__tests__/12-scheduler.test.ts",
+      "target": "module:sender:src/core/sender.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:12-scheduler.test:__tests__/12-scheduler.test.ts",
+      "target": "module:scheduler:src/utils/scheduler.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:12-scheduler.test:__tests__/12-scheduler.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:13-security-injection.test:__tests__/13-security-injection.test.ts",
+      "target": "module:applescript:src/utils/applescript.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:14-reactions.test:__tests__/14-reactions.test.ts",
+      "target": "module:database:src/core/database.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:14-reactions.test:__tests__/14-reactions.test.ts",
+      "target": "module:setup:__tests__/setup.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:15-tempfile-security.test:__tests__/15-tempfile-security.test.ts",
+      "target": "module:applescript:src/utils/applescript.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:16-imessage-service-routing.test:__tests__/16-imessage-service-routing.test.ts",
+      "target": "module:applescript:src/utils/applescript.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "function:initTestDatabase:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "function:createTempDir:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "function:cleanupTempDir:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "function:createMockDatabase:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "function:insertTestMessage:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "function:mockAppleScript:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "function:waitFor:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "function:createSpy:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "function:createMockDatabase:__tests__/setup.ts",
+      "target": "function:createMockDatabase.cleanup:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:setup:__tests__/setup.ts",
+      "target": "class:MockWebhookServer:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MockWebhookServer:__tests__/setup.ts",
+      "target": "function:MockWebhookServer.getRequests:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MockWebhookServer:__tests__/setup.ts",
+      "target": "function:MockWebhookServer.reset:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MockWebhookServer:__tests__/setup.ts",
+      "target": "function:MockWebhookServer.receive:__tests__/setup.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:01-send-text:examples/01-send-text.ts",
+      "target": "kafka-producer:pilot_photon.codes:examples/01-send-text.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:01-send-text:examples/01-send-text.ts",
+      "target": "kafka-producer:Hello_World:examples/01-send-text.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:01-send-text:examples/01-send-text.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:02-send-image:examples/02-send-image.ts",
+      "target": "kafka-producer:pilot_photon.codes:examples/02-send-image.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:02-send-image:examples/02-send-image.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:03-send-file:examples/03-send-file.ts",
+      "target": "kafka-producer:pilot_photon.codes:examples/03-send-file.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:03-send-file:examples/03-send-file.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:04-send-group:examples/04-send-group.ts",
+      "target": "kafka-producer:iMessage___chat493787071395575843:examples/04-send-group.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:04-send-group:examples/04-send-group.ts",
+      "target": "kafka-producer:Hello_everyone:examples/04-send-group.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:04-send-group:examples/04-send-group.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:05-query-messages:examples/05-query-messages.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:06-list-chats:examples/06-list-chats.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:07-watch-messages:examples/07-watch-messages.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:08-auto-reply:examples/08-auto-reply.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:09-batch-send:examples/09-batch-send.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:10-get-sent-message:examples/10-get-sent-message.ts",
+      "target": "kafka-producer:pilot_photon.codes:examples/10-get-sent-message.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:10-get-sent-message:examples/10-get-sent-message.ts",
+      "target": "kafka-producer:Test_message:examples/10-get-sent-message.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:10-get-sent-message:examples/10-get-sent-message.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:11-plugin:examples/11-plugin.ts",
+      "target": "kafka-producer:pilot_photon.codes:examples/11-plugin.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:11-plugin:examples/11-plugin.ts",
+      "target": "kafka-producer:Test_with_plugin:examples/11-plugin.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:11-plugin:examples/11-plugin.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:12-error-handling:examples/12-error-handling.ts",
+      "target": "kafka-producer:invalid-recipient:examples/12-error-handling.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:12-error-handling:examples/12-error-handling.ts",
+      "target": "kafka-producer:Test:examples/12-error-handling.ts",
+      "relationship": "produces"
+    },
+    {
+      "source": "module:12-error-handling:examples/12-error-handling.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:13-watch-own-messages:examples/13-watch-own-messages.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:14-scheduled-messages:examples/14-scheduled-messages.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:15-smart-reminders:examples/15-smart-reminders.ts",
+      "target": "module:src:src.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:chain:src/core/chain.ts",
+      "target": "class:MessageChain:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.when:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.matchText:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.ifUnread:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.ifFromOthers:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.ifFromMe:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.ifGroupChat:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.ifReaction:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.ifNotReaction:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.replyText:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.replyImage:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.do:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageChain:src/core/chain.ts",
+      "target": "function:MessageChain.execute:src/core/chain.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:chain:src/core/chain.ts",
+      "target": "module:advanced:src/types/advanced.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:chain:src/core/chain.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:chain:src/core/chain.ts",
+      "target": "module:common:src/utils/common.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:chain:src/core/chain.ts",
+      "target": "module:sender:src/core/sender.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:database:src/core/database.ts",
+      "target": "function:initDatabase:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:database:src/core/database.ts",
+      "target": "function:str:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:database:src/core/database.ts",
+      "target": "function:num:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:database:src/core/database.ts",
+      "target": "function:bool:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:database:src/core/database.ts",
+      "target": "class:IMessageDatabase:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.init:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.ensureInit:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.getMessages:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.getUnreadMessages:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.listChats:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.getAttachments:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.extractTextFromAttributedBody:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.mapService:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.mapReactionType:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.convertMacTimestamp:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageDatabase:src/core/database.ts",
+      "target": "function:IMessageDatabase.close:src/core/database.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:database:src/core/database.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:database:src/core/database.ts",
+      "target": "module:errors:src/core/errors.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:errors:src/core/errors.ts",
+      "target": "function:PlatformError:src/core/errors.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:errors:src/core/errors.ts",
+      "target": "function:DatabaseError:src/core/errors.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:errors:src/core/errors.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:errors:src/core/errors.ts",
+      "target": "function:WebhookError:src/core/errors.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:errors:src/core/errors.ts",
+      "target": "function:ConfigError:src/core/errors.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:errors:src/core/errors.ts",
+      "target": "class:IMessageError:src/core/errors.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageError:src/core/errors.ts",
+      "target": "class:Error:*",
+      "relationship": "extends"
+    },
+    {
+      "source": "class:IMessageError:src/core/errors.ts",
+      "target": "function:IMessageError.is:src/core/errors.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:message-promise:src/core/message-promise.ts",
+      "target": "class:MessagePromiseRejection:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessagePromiseRejection:src/core/message-promise.ts",
+      "target": "class:Error:*",
+      "relationship": "extends"
+    },
+    {
+      "source": "module:message-promise:src/core/message-promise.ts",
+      "target": "class:MessagePromise:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessagePromise:src/core/message-promise.ts",
+      "target": "function:MessagePromise.normalizeText:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessagePromise:src/core/message-promise.ts",
+      "target": "function:MessagePromise.getFilenameWithoutExtension:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessagePromise:src/core/message-promise.ts",
+      "target": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessagePromise:src/core/message-promise.ts",
+      "target": "function:MessagePromise.reject:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessagePromise:src/core/message-promise.ts",
+      "target": "function:MessagePromise.matches:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessagePromise:src/core/message-promise.ts",
+      "target": "function:MessagePromise.matchesChatId:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessagePromise:src/core/message-promise.ts",
+      "target": "function:MessagePromise.normalizeChatId:src/core/message-promise.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:message-promise:src/core/message-promise.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:outgoing-manager:src/core/outgoing-manager.ts",
+      "target": "class:OutgoingMessageManager:src/core/outgoing-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:OutgoingMessageManager:src/core/outgoing-manager.ts",
+      "target": "function:OutgoingMessageManager.add:src/core/outgoing-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:OutgoingMessageManager:src/core/outgoing-manager.ts",
+      "target": "function:OutgoingMessageManager.tryResolve:src/core/outgoing-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:OutgoingMessageManager:src/core/outgoing-manager.ts",
+      "target": "function:OutgoingMessageManager.cleanup:src/core/outgoing-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:OutgoingMessageManager:src/core/outgoing-manager.ts",
+      "target": "function:OutgoingMessageManager.getPendingCount:src/core/outgoing-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:OutgoingMessageManager:src/core/outgoing-manager.ts",
+      "target": "function:OutgoingMessageManager.rejectAll:src/core/outgoing-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:outgoing-manager:src/core/outgoing-manager.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:outgoing-manager:src/core/outgoing-manager.ts",
+      "target": "module:message-promise:src/core/message-promise.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "function:IMessageSDK.resolveConfig.clamp:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "class:IMessageSDK:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.ensurePluginsReady:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.resolveConfig:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.isChatId:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.use:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.getMessages:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.getUnreadMessages:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.send:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.listChats:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.sendBatch:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.sendFile:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.sendFiles:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.message:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.startWatching:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.stopWatching:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK.close:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK._Symbol.asyncDispose_:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:IMessageSDK:src/core/sdk.ts",
+      "target": "function:IMessageSDK._Symbol.dispose_:src/core/sdk.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:core:src/plugins/core.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:advanced:src/types/advanced.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:config:src/types/config.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:common:src/utils/common.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:platform:src/utils/platform.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:temp-file-manager:src/utils/temp-file-manager.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:chain:src/core/chain.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:constants:src/core/constants.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:database:src/core/database.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:outgoing-manager:src/core/outgoing-manager.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:sender:src/core/sender.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sdk:src/core/sdk.ts",
+      "target": "module:watcher:src/core/watcher.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "function:MessageSender.send.task:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "class:MessageSender:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.setOutgoingManager:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.executeWithRetry:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.send:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.checkAbortSignal:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.prepareAttachments:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.sendToRecipient:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageSender:src/core/sender.ts",
+      "target": "function:MessageSender.sendToGroup:src/core/sender.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:advanced:src/types/advanced.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:config:src/types/config.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:applescript:src/utils/applescript.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:common:src/utils/common.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:download:src/utils/download.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:semaphore:src/utils/semaphore.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:errors:src/core/errors.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:message-promise:src/core/message-promise.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:sender:src/core/sender.ts",
+      "target": "module:outgoing-manager:src/core/outgoing-manager.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:watcher:src/core/watcher.ts",
+      "target": "class:MessageWatcher:src/core/watcher.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageWatcher:src/core/watcher.ts",
+      "target": "function:MessageWatcher.start:src/core/watcher.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageWatcher:src/core/watcher.ts",
+      "target": "function:MessageWatcher.stop:src/core/watcher.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageWatcher:src/core/watcher.ts",
+      "target": "function:MessageWatcher.check:src/core/watcher.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageWatcher:src/core/watcher.ts",
+      "target": "function:MessageWatcher.handleNewMessage:src/core/watcher.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageWatcher:src/core/watcher.ts",
+      "target": "function:MessageWatcher.sendWebhook:src/core/watcher.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageWatcher:src/core/watcher.ts",
+      "target": "function:MessageWatcher.handleError:src/core/watcher.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:watcher:src/core/watcher.ts",
+      "target": "module:core:src/plugins/core.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:watcher:src/core/watcher.ts",
+      "target": "module:config:src/types/config.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:watcher:src/core/watcher.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:watcher:src/core/watcher.ts",
+      "target": "module:database:src/core/database.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:watcher:src/core/watcher.ts",
+      "target": "module:errors:src/core/errors.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:watcher:src/core/watcher.ts",
+      "target": "module:outgoing-manager:src/core/outgoing-manager.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:attachmentExists:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:downloadAttachment:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:getAttachmentSize:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:getAttachmentMetadata:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:readAttachment:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:getAttachmentExtension:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:isImageAttachment:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:isVideoAttachment:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "function:isAudioAttachment:src/helpers/attachment.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:attachment:src/helpers/attachment.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:core:src/plugins/core.ts",
+      "target": "function:definePlugin:src/plugins/core.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:core:src/plugins/core.ts",
+      "target": "class:PluginManager:src/plugins/core.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:PluginManager:src/plugins/core.ts",
+      "target": "function:PluginManager.use:src/plugins/core.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:PluginManager:src/plugins/core.ts",
+      "target": "function:PluginManager.init:src/plugins/core.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:PluginManager:src/plugins/core.ts",
+      "target": "function:PluginManager.destroy:src/plugins/core.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:PluginManager:src/plugins/core.ts",
+      "target": "function:PluginManager.callHookForAll:src/plugins/core.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:core:src/plugins/core.ts",
+      "target": "module:sender:src/core/sender.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:core:src/plugins/core.ts",
+      "target": "module:message:src/types/message.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:logger:src/plugins/logger.ts",
+      "target": "function:loggerPlugin:src/plugins/logger.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "function:loggerPlugin:src/plugins/logger.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:logger:src/plugins/logger.ts",
+      "target": "module:core:src/plugins/core.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:advanced:src/types/advanced.ts",
+      "target": "function:hasMinDigits:src/types/advanced.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:advanced:src/types/advanced.ts",
+      "target": "function:asRecipient:src/types/advanced.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:advanced:src/types/advanced.ts",
+      "target": "function:isURL:src/types/advanced.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:config:src/types/config.ts",
+      "target": "module:core:src/plugins/core.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:needsSandboxBypass:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:buildTempFilenameTemplate:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:calculateFileDelay:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateSandboxBypassScript:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateDirectSendScript:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateDirectSendScriptForChat:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:execAppleScript:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:checkMessagesApp:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:checkIMessageStatus:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateSendTextScript:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateSendTextToChat:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateSendAttachmentScript:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:applescript:src/utils/applescript.ts",
+      "target": "function:generateSendWithAttachmentToChat:src/utils/applescript.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:common:src/utils/common.ts",
+      "target": "function:validateMessageContent:src/utils/common.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:common:src/utils/common.ts",
+      "target": "function:normalizeChatId:src/utils/common.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:common:src/utils/common.ts",
+      "target": "function:isGroupChatId:src/utils/common.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:common:src/utils/common.ts",
+      "target": "function:extractRecipientFromChatId:src/utils/common.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:common:src/utils/common.ts",
+      "target": "function:validateChatId:src/utils/common.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:common:src/utils/common.ts",
+      "target": "function:delay:src/utils/common.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:download:src/utils/download.ts",
+      "target": "function:generateSecureFilename:src/utils/download.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:download:src/utils/download.ts",
+      "target": "function:convertImageToJPEG:src/utils/download.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:download:src/utils/download.ts",
+      "target": "function:downloadImage:src/utils/download.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:download:src/utils/download.ts",
+      "target": "function:convertToCompatibleFormat:src/utils/download.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:download:src/utils/download.ts",
+      "target": "module:errors:src/core/errors.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:download:src/utils/download.ts",
+      "target": "module:common:src/utils/common.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:platform:src/utils/platform.ts",
+      "target": "function:requireMacOS:src/utils/platform.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:platform:src/utils/platform.ts",
+      "target": "function:isMacOS:src/utils/platform.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:platform:src/utils/platform.ts",
+      "target": "function:getDefaultDatabasePath:src/utils/platform.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:platform:src/utils/platform.ts",
+      "target": "module:errors:src/core/errors.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:reminders:src/utils/reminders.ts",
+      "target": "function:parseDuration:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:reminders:src/utils/reminders.ts",
+      "target": "function:parseTime:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:reminders:src/utils/reminders.ts",
+      "target": "function:parseAtExpression:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:reminders:src/utils/reminders.ts",
+      "target": "class:Reminders:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.in:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.at:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.exact:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.scheduleReminder:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.cancel:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.get:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.list:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.count:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Reminders:src/utils/reminders.ts",
+      "target": "function:Reminders.destroy:src/utils/reminders.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:reminders:src/utils/reminders.ts",
+      "target": "module:sdk:src/core/sdk.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:reminders:src/utils/reminders.ts",
+      "target": "module:scheduler:src/utils/scheduler.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:scheduler:src/utils/scheduler.ts",
+      "target": "function:generateId:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:scheduler:src/utils/scheduler.ts",
+      "target": "function:calculateNextSendTime:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:scheduler:src/utils/scheduler.ts",
+      "target": "class:MessageScheduler:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.schedule:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.scheduleRecurring:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.cancel:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.reschedule:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.get:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.getPending:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.export:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.import:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.start:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.tick:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.sendMessage:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.sendRecurringMessage:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:MessageScheduler:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.destroy:src/utils/scheduler.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:scheduler:src/utils/scheduler.ts",
+      "target": "module:sdk:src/core/sdk.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:scheduler:src/utils/scheduler.ts",
+      "target": "module:sender:src/core/sender.ts",
+      "relationship": "imports"
+    },
+    {
+      "source": "module:semaphore:src/utils/semaphore.ts",
+      "target": "class:Semaphore:src/utils/semaphore.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Semaphore:src/utils/semaphore.ts",
+      "target": "function:Semaphore.acquire:src/utils/semaphore.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:Semaphore:src/utils/semaphore.ts",
+      "target": "function:Semaphore.run:src/utils/semaphore.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "module:temp-file-manager:src/utils/temp-file-manager.ts",
+      "target": "class:TempFileManager:src/utils/temp-file-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:TempFileManager:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.start:src/utils/temp-file-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:TempFileManager:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.cleanup:src/utils/temp-file-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:TempFileManager:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.cleanupAll:src/utils/temp-file-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:TempFileManager:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.stop:src/utils/temp-file-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:TempFileManager:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.destroy:src/utils/temp-file-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "class:TempFileManager:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.getStats:src/utils/temp-file-manager.ts",
+      "relationship": "exposes"
+    },
+    {
+      "source": "function:scheduler:demo.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:countdown:demo.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:task:__tests__/02-utils.test.ts",
+      "target": "function:Semaphore.acquire:src/utils/semaphore.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:sendSpy:__tests__/06-sdk-core.test.ts",
+      "target": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:createMockSDK:__tests__/12-scheduler.test.ts",
+      "target": "function:createSpy:__tests__/setup.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:createMockDatabase:__tests__/setup.ts",
+      "target": "function:IMessageDatabase.close:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:insertTestMessage:__tests__/setup.ts",
+      "target": "function:Reminders.get:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:insertTestMessage:__tests__/setup.ts",
+      "target": "function:Semaphore.run:src/utils/semaphore.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:myPlugin:examples/11-plugin.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:scheduler:examples/14-scheduled-messages.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:reminders:examples/15-smart-reminders.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageChain.matchText:src/core/chain.ts",
+      "target": "function:MessageChain.when:src/core/chain.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageChain.ifUnread:src/core/chain.ts",
+      "target": "function:MessageChain.when:src/core/chain.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageChain.ifFromOthers:src/core/chain.ts",
+      "target": "function:MessageChain.when:src/core/chain.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageChain.ifFromMe:src/core/chain.ts",
+      "target": "function:MessageChain.when:src/core/chain.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageChain.ifGroupChat:src/core/chain.ts",
+      "target": "function:MessageChain.when:src/core/chain.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageChain.ifReaction:src/core/chain.ts",
+      "target": "function:MessageChain.when:src/core/chain.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageChain.ifNotReaction:src/core/chain.ts",
+      "target": "function:MessageChain.when:src/core/chain.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:initDatabase:src/core/database.ts",
+      "target": "function:DatabaseError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.init:src/core/database.ts",
+      "target": "function:initDatabase:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.init:src/core/database.ts",
+      "target": "function:DatabaseError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.getMessages:src/core/database.ts",
+      "target": "function:IMessageDatabase.ensureInit:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.getMessages.messages:src/core/database.ts",
+      "target": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.getMessages:src/core/database.ts",
+      "target": "function:DatabaseError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.getUnreadMessages:src/core/database.ts",
+      "target": "function:IMessageDatabase.getMessages:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.getUnreadMessages:src/core/database.ts",
+      "target": "function:Reminders.get:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.listChats:src/core/database.ts",
+      "target": "function:IMessageDatabase.ensureInit:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.listChats:src/core/database.ts",
+      "target": "function:DatabaseError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.getAttachments:src/core/database.ts",
+      "target": "function:IMessageDatabase.ensureInit:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "target": "function:IMessageDatabase.extractTextFromAttributedBody:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "target": "function:str:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "target": "function:IMessageDatabase.mapReactionType:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "target": "function:bool:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "target": "function:IMessageDatabase.mapService:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "target": "function:IMessageDatabase.getAttachments:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.rowToMessage:src/core/database.ts",
+      "target": "function:IMessageDatabase.convertMacTimestamp:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageDatabase.close:src/core/database.ts",
+      "target": "function:IMessageDatabase.ensureInit:src/core/database.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessagePromise.matches:src/core/message-promise.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessagePromise.matches:src/core/message-promise.ts",
+      "target": "function:MessagePromise.matchesChatId:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessagePromise.matches:src/core/message-promise.ts",
+      "target": "function:MessagePromise.getFilenameWithoutExtension:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessagePromise.matches.match:src/core/message-promise.ts",
+      "target": "function:MessagePromise.getFilenameWithoutExtension:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessagePromise.matches:src/core/message-promise.ts",
+      "target": "function:MessagePromise.normalizeText:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessagePromise.matchesChatId:src/core/message-promise.ts",
+      "target": "function:MessagePromise.normalizeChatId:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:OutgoingMessageManager.add:src/core/outgoing-manager.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:OutgoingMessageManager.tryResolve:src/core/outgoing-manager.ts",
+      "target": "function:MessagePromise.matches:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:OutgoingMessageManager.tryResolve:src/core/outgoing-manager.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:OutgoingMessageManager.tryResolve:src/core/outgoing-manager.ts",
+      "target": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:OutgoingMessageManager.rejectAll:src/core/outgoing-manager.ts",
+      "target": "function:MessagePromise.reject:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:IMessageSDK.resolveConfig:src/core/sdk.ts",
+      "target": "function:getDefaultDatabasePath:src/utils/platform.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.resolveConfig:src/core/sdk.ts",
+      "target": "function:IMessageSDK.resolveConfig.clamp:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.isChatId:src/core/sdk.ts",
+      "target": "function:isGroupChatId:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:IMessageSDK.isChatId:src/core/sdk.ts",
+      "target": "function:asRecipient:src/types/advanced.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.isChatId:src/core/sdk.ts",
+      "target": "function:extractRecipientFromChatId:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.getMessages:src/core/sdk.ts",
+      "target": "function:IMessageSDK.ensurePluginsReady:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.getUnreadMessages:src/core/sdk.ts",
+      "target": "function:IMessageSDK.ensurePluginsReady:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.send:src/core/sdk.ts",
+      "target": "function:IMessageSDK.isChatId:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.send:src/core/sdk.ts",
+      "target": "function:validateChatId:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:IMessageSDK.send:src/core/sdk.ts",
+      "target": "function:IMessageSDK.ensurePluginsReady:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:IMessageSDK.send:src/core/sdk.ts",
+      "target": "function:extractRecipientFromChatId:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.send:src/core/sdk.ts",
+      "target": "function:asRecipient:src/types/advanced.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.listChats:src/core/sdk.ts",
+      "target": "function:IMessageSDK.ensurePluginsReady:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.sendBatch.results:src/core/sdk.ts",
+      "target": "function:IMessageSDK.send:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.sendFile:src/core/sdk.ts",
+      "target": "function:IMessageSDK.send:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.sendFiles:src/core/sdk.ts",
+      "target": "function:IMessageSDK.send:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.startWatching:src/core/sdk.ts",
+      "target": "function:MessageWatcher.start:src/core/watcher.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK.startWatching:src/core/sdk.ts",
+      "target": "function:MessageWatcher.stop:src/core/watcher.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK._Symbol.asyncDispose_:src/core/sdk.ts",
+      "target": "function:IMessageSDK.close:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:IMessageSDK._Symbol.dispose_:src/core/sdk.ts",
+      "target": "function:IMessageSDK.close:src/core/sdk.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.executeWithRetry:src/core/sender.ts",
+      "target": "function:delay:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.executeWithRetry:src/core/sender.ts",
+      "target": "function:execAppleScript:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.executeWithRetry:src/core/sender.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "target": "function:isURL:src/types/advanced.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "target": "function:downloadImage:src/utils/download.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "target": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "target": "function:convertToCompatibleFormat:src/utils/download.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.send.task:src/core/sender.ts",
+      "target": "function:MessageSender.checkAbortSignal:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.send.task:src/core/sender.ts",
+      "target": "function:validateMessageContent:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.send.task:src/core/sender.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.send.task:src/core/sender.ts",
+      "target": "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.send.task:src/core/sender.ts",
+      "target": "function:MessageSender.prepareAttachments:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.send.task:src/core/sender.ts",
+      "target": "function:asRecipient:src/types/advanced.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.send.task:src/core/sender.ts",
+      "target": "function:MessageSender.sendToRecipient:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.send.task:src/core/sender.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.send:src/core/sender.ts",
+      "target": "function:MessageSender.send.task:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.checkAbortSignal:src/core/sender.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts",
+      "target": "function:checkMessagesApp:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts",
+      "target": "function:checkIMessageStatus:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.prepareAttachments:src/core/sender.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.prepareAttachments:src/core/sender.ts",
+      "target": "function:MessageSender.resolveAttachment:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToRecipient:src/core/sender.ts",
+      "target": "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToRecipient:src/core/sender.ts",
+      "target": "function:MessageSender.executeWithRetry:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToRecipient:src/core/sender.ts",
+      "target": "function:generateSendAttachmentScript:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToRecipient:src/core/sender.ts",
+      "target": "function:delay:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToRecipient:src/core/sender.ts",
+      "target": "function:generateSendTextScript:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+      "target": "function:generateSendWithAttachmentToChat:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+      "target": "function:MessageSender.executeWithRetry:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+      "target": "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+      "target": "function:delay:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+      "target": "function:generateSendTextToChat:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "target": "function:MessageSender.checkAbortSignal:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "target": "function:validateChatId:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "target": "function:validateMessageContent:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "target": "function:MessageSender.checkMessagesEnvironment:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "target": "function:MessageSender.prepareAttachments:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "target": "function:MessageSender.sendToGroupChat:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup.task:src/core/sender.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageSender.sendToGroup:src/core/sender.ts",
+      "target": "function:MessageSender.send.task:src/core/sender.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageWatcher.start:src/core/watcher.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageWatcher.start:src/core/watcher.ts",
+      "target": "function:MessageWatcher.check:src/core/watcher.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageWatcher.stop:src/core/watcher.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageWatcher.check:src/core/watcher.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageWatcher.check:src/core/watcher.ts",
+      "target": "function:MessageWatcher.handleError:src/core/watcher.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageWatcher.handleNewMessage:src/core/watcher.ts",
+      "target": "function:MessageWatcher.sendWebhook:src/core/watcher.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageWatcher.handleNewMessage:src/core/watcher.ts",
+      "target": "function:MessageWatcher.handleError:src/core/watcher.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageWatcher.sendWebhook:src/core/watcher.ts",
+      "target": "function:WebhookError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:isImageAttachment:src/helpers/attachment.ts",
+      "target": "function:getAttachmentExtension:src/helpers/attachment.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:isVideoAttachment:src/helpers/attachment.ts",
+      "target": "function:getAttachmentExtension:src/helpers/attachment.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:isAudioAttachment:src/helpers/attachment.ts",
+      "target": "function:getAttachmentExtension:src/helpers/attachment.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:PluginManager.use:src/plugins/core.ts",
+      "target": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:PluginManager.init:src/plugins/core.ts",
+      "target": "function:PluginManager.callHookForAll:src/plugins/core.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:PluginManager.destroy:src/plugins/core.ts",
+      "target": "function:PluginManager.callHookForAll:src/plugins/core.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:PluginManager.callHookForAll.results:src/plugins/core.ts",
+      "target": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:loggerPlugin:src/plugins/logger.ts",
+      "target": "function:definePlugin:src/plugins/core.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:loggerPlugin:src/plugins/logger.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:asRecipient:src/types/advanced.ts",
+      "target": "function:hasMinDigits:src/types/advanced.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:execAppleScript:src/utils/applescript.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:checkIMessageStatus:src/utils/applescript.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendTextScript:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendTextToChat:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSandboxBypassScript:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSandboxBypassScript:src/utils/applescript.ts",
+      "target": "function:buildTempFilenameTemplate:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSandboxBypassScript:src/utils/applescript.ts",
+      "target": "function:calculateFileDelay:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+      "target": "function:buildTempFilenameTemplate:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+      "target": "function:calculateFileDelay:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateDirectSendScript:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateDirectSendScript:src/utils/applescript.ts",
+      "target": "function:calculateFileDelay:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateDirectSendScriptForChat:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateDirectSendScriptForChat:src/utils/applescript.ts",
+      "target": "function:calculateFileDelay:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentScript:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentScript:src/utils/applescript.ts",
+      "target": "function:needsSandboxBypass:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentScript:src/utils/applescript.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentScript:src/utils/applescript.ts",
+      "target": "function:generateSandboxBypassScript:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentScript:src/utils/applescript.ts",
+      "target": "function:generateDirectSendScript:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:needsSandboxBypass:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:generateDirectSendScriptForChat:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+      "target": "function:needsSandboxBypass:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+      "target": "function:generateSandboxBypassScript:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendWithAttachmentScript:src/utils/applescript.ts",
+      "target": "function:generateDirectSendScript:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendWithAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:escapeAppleScriptString:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendWithAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:needsSandboxBypass:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:generateSendWithAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:generateSandboxBypassScriptForChat:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:generateSendWithAttachmentToChat:src/utils/applescript.ts",
+      "target": "function:generateDirectSendScriptForChat:src/utils/applescript.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:extractRecipientFromChatId:src/utils/common.ts",
+      "target": "function:isGroupChatId:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:convertImageToJPEG:src/utils/download.ts",
+      "target": "function:generateSecureFilename:src/utils/download.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:convertImageToJPEG:src/utils/download.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:downloadImage:src/utils/download.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:downloadImage:src/utils/download.ts",
+      "target": "function:delay:src/utils/common.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:downloadImage:src/utils/download.ts",
+      "target": "function:Reminders.get:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:downloadImage:src/utils/download.ts",
+      "target": "function:generateSecureFilename:src/utils/download.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:downloadImage:src/utils/download.ts",
+      "target": "function:convertImageToJPEG:src/utils/download.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:downloadImage:src/utils/download.ts",
+      "target": "function:SendError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:convertToCompatibleFormat:src/utils/download.ts",
+      "target": "function:generateSecureFilename:src/utils/download.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:convertToCompatibleFormat:src/utils/download.ts",
+      "target": "function:convertImageToJPEG:src/utils/download.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:requireMacOS:src/utils/platform.ts",
+      "target": "function:PlatformError:src/core/errors.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:parseAtExpression:src/utils/reminders.ts",
+      "target": "function:parseTime:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:Reminders.in:src/utils/reminders.ts",
+      "target": "function:parseDuration:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:Reminders.in:src/utils/reminders.ts",
+      "target": "function:Reminders.scheduleReminder:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:Reminders.at:src/utils/reminders.ts",
+      "target": "function:parseAtExpression:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:Reminders.at:src/utils/reminders.ts",
+      "target": "function:Reminders.scheduleReminder:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:Reminders.exact:src/utils/reminders.ts",
+      "target": "function:Reminders.scheduleReminder:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:Reminders.count:src/utils/reminders.ts",
+      "target": "function:Reminders.get:src/utils/reminders.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.schedule:src/utils/scheduler.ts",
+      "target": "function:generateId:src/utils/scheduler.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageScheduler.schedule:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.scheduleRecurring:src/utils/scheduler.ts",
+      "target": "function:generateId:src/utils/scheduler.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageScheduler.scheduleRecurring:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.cancel:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.get:src/utils/scheduler.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageScheduler.cancel:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.reschedule:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.get:src/utils/scheduler.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageScheduler.reschedule:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.import:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.start:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.tick:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.sendMessage:src/utils/scheduler.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageScheduler.tick:src/utils/scheduler.ts",
+      "target": "function:calculateNextSendTime:src/utils/scheduler.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageScheduler.tick:src/utils/scheduler.ts",
+      "target": "function:MessageScheduler.sendRecurringMessage:src/utils/scheduler.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:MessageScheduler.tick:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.sendMessage:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.sendRecurringMessage:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:MessageScheduler.destroy:src/utils/scheduler.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:Semaphore.run:src/utils/semaphore.ts",
+      "target": "function:Semaphore.acquire:src/utils/semaphore.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:TempFileManager.start:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.cleanup:src/utils/temp-file-manager.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:TempFileManager.start:src/utils/temp-file-manager.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:TempFileManager.cleanup:src/utils/temp-file-manager.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:TempFileManager.cleanupAll:src/utils/temp-file-manager.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": true,
+        "isInLoop": true,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:TempFileManager.destroy:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.stop:src/utils/temp-file-manager.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:TempFileManager.destroy:src/utils/temp-file-manager.ts",
+      "target": "function:TempFileManager.cleanupAll:src/utils/temp-file-manager.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": false
+      }
+    },
+    {
+      "source": "function:TempFileManager.destroy:src/utils/temp-file-manager.ts",
+      "target": "function:loggerPlugin.log:src/plugins/logger.ts",
+      "relationship": "calls",
+      "metadata": {
+        "isInErrorHandler": false,
+        "isInLoop": false,
+        "isConditional": true
+      }
+    },
+    {
+      "source": "function:createMockDatabase.cleanup:__tests__/setup.ts",
+      "target": "function:IMessageSDK.close:src/core/sdk.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:extractTextFromAttributedBody:__tests__/12-attributed-body.test.ts",
+      "target": "function:IMessageDatabase.extractTextFromAttributedBody:src/core/database.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:Reminders.scheduleReminder:src/utils/reminders.ts",
+      "target": "function:MessageScheduler.schedule:src/utils/scheduler.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:Reminders.cancel:src/utils/reminders.ts",
+      "target": "function:MessageScheduler.cancel:src/utils/scheduler.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:Reminders.get:src/utils/reminders.ts",
+      "target": "function:MessageScheduler.get:src/utils/scheduler.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:Reminders.list:src/utils/reminders.ts",
+      "target": "function:MessageScheduler.get:src/utils/scheduler.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:Reminders.destroy:src/utils/reminders.ts",
+      "target": "function:TempFileManager.destroy:src/utils/temp-file-manager.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:PluginManager.callHookForAll:src/plugins/core.ts",
+      "target": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:IMessageSDK.ensurePluginsReady:src/core/sdk.ts",
+      "target": "function:PluginManager.init:src/plugins/core.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:IMessageSDK.use:src/core/sdk.ts",
+      "target": "function:PluginManager.use:src/plugins/core.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:IMessageSDK.sendBatch:src/core/sdk.ts",
+      "target": "function:MessageSender.send:src/core/sender.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:IMessageSDK.stopWatching:src/core/sdk.ts",
+      "target": "function:TempFileManager.stop:src/utils/temp-file-manager.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:IMessageSDK.close:src/core/sdk.ts",
+      "target": "function:TempFileManager.stop:src/utils/temp-file-manager.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:IMessageSDK.close:src/core/sdk.ts",
+      "target": "function:OutgoingMessageManager.rejectAll:src/core/outgoing-manager.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:IMessageSDK.close:src/core/sdk.ts",
+      "target": "function:TempFileManager.destroy:src/utils/temp-file-manager.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:OutgoingMessageManager.cleanup:src/core/outgoing-manager.ts",
+      "target": "function:TempFileManager.cleanup:src/utils/temp-file-manager.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessagePromise.normalizeChatId:src/core/message-promise.ts",
+      "target": "function:normalizeChatId:src/utils/common.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyText:src/core/chain.ts",
+      "target": "function:isGroupChatId:src/utils/common.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyText:src/core/chain.ts",
+      "target": "function:MessageSender.sendToGroup:src/core/sender.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyText:src/core/chain.ts",
+      "target": "function:extractRecipientFromChatId:src/utils/common.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyText:src/core/chain.ts",
+      "target": "function:asRecipient:src/types/advanced.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyText:src/core/chain.ts",
+      "target": "function:MessageSender.send:src/core/sender.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyImage:src/core/chain.ts",
+      "target": "function:isGroupChatId:src/utils/common.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyImage:src/core/chain.ts",
+      "target": "function:MessageSender.sendToGroup:src/core/sender.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyImage:src/core/chain.ts",
+      "target": "function:extractRecipientFromChatId:src/utils/common.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyImage:src/core/chain.ts",
+      "target": "function:asRecipient:src/types/advanced.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.replyImage:src/core/chain.ts",
+      "target": "function:MessageSender.send:src/core/sender.ts",
+      "relationship": "calls"
+    },
+    {
+      "source": "function:MessageChain.do:src/core/chain.ts",
+      "target": "function:MessagePromise.resolve:src/core/message-promise.ts",
+      "relationship": "calls"
+    }
+  ],
+  "metrics": {
+    "totalNodes": 269,
+    "totalEdges": 554,
+    "totalFunctions": 181,
+    "avgImpactScore": 4,
+    "maxImpactScore": 65,
+    "nodesWithReverseEdges": 101,
+    "crossServiceConnections": 0
+  }
+}

--- a/__tests__/02-utils.test.ts
+++ b/__tests__/02-utils.test.ts
@@ -169,9 +169,7 @@ describe('Common Utils', () => {
             expect(normalizeChatId('iMessage;+;chat45e2b868ce1e43da89af262922733382')).toBe(
                 'chat45e2b868ce1e43da89af262922733382'
             )
-            expect(normalizeChatId('any;+;534ce85d174c4709b8e84075f9078b04')).toBe(
-                '534ce85d174c4709b8e84075f9078b04'
-            )
+            expect(normalizeChatId('any;+;534ce85d174c4709b8e84075f9078b04')).toBe('534ce85d174c4709b8e84075f9078b04')
             expect(normalizeChatId('any;-;+1234567890')).toBe('+1234567890')
             expect(normalizeChatId('iMessage;+1234567890')).toBe('+1234567890')
         })

--- a/__tests__/02-utils.test.ts
+++ b/__tests__/02-utils.test.ts
@@ -162,20 +162,26 @@ describe('Common Utils', () => {
     })
 
     describe('normalizeChatId', () => {
-        it('should normalize AppleScript group format to GUID', async () => {
+        it('should extract core identifier from semicolon formats', async () => {
             const { normalizeChatId } = await import('../src/utils/common')
 
             expect(normalizeChatId('iMessage;+;chat61321855167474084')).toBe('chat61321855167474084')
             expect(normalizeChatId('iMessage;+;chat45e2b868ce1e43da89af262922733382')).toBe(
                 'chat45e2b868ce1e43da89af262922733382'
             )
+            expect(normalizeChatId('any;+;534ce85d174c4709b8e84075f9078b04')).toBe(
+                '534ce85d174c4709b8e84075f9078b04'
+            )
+            expect(normalizeChatId('any;-;+1234567890')).toBe('+1234567890')
+            expect(normalizeChatId('iMessage;+1234567890')).toBe('+1234567890')
         })
 
-        it('should return unchanged for other formats', async () => {
+        it('should return unchanged for bare formats', async () => {
             const { normalizeChatId } = await import('../src/utils/common')
 
             expect(normalizeChatId('chat61321855167474084')).toBe('chat61321855167474084')
-            expect(normalizeChatId('iMessage;+1234567890')).toBe('iMessage;+1234567890')
+            expect(normalizeChatId('+1234567890')).toBe('+1234567890')
+            expect(normalizeChatId('534ce85d174c4709b8e84075f9078b04')).toBe('534ce85d174c4709b8e84075f9078b04')
         })
     })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,9 +92,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -112,9 +109,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -132,9 +126,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -152,9 +143,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -98,6 +98,20 @@ export class IMessageDatabase {
     }
 
     /**
+     * Resolve a chatId from database columns using consistent rules:
+     * - Groups (or missing identifier): use chat.guid, fall back to chat_identifier
+     * - DMs with semicolons already in identifier: use as-is
+     * - DMs with service: prefix with service name
+     * - DMs without service: prefix with "iMessage"
+     */
+    private resolveChatId(isGroup: boolean, chatGuid: string, chatIdentifier: string, chatService: string): string {
+        if (isGroup || !chatIdentifier) return chatGuid || chatIdentifier
+        if (chatIdentifier.includes(';')) return chatIdentifier
+        if (chatService) return `${chatService};${chatIdentifier}`
+        return `iMessage;${chatIdentifier}`
+    }
+
+    /**
      * Query messages (with multiple filter options)
      *
      * @param filter Filter conditions (optional)
@@ -352,24 +366,12 @@ export class IMessageDatabase {
             const rows = this.db.prepare(query).all(...params) as Array<Record<string, unknown>>
             return rows.map((row) => {
                 const isGroup = bool(row.is_group_chat)
-                const guid = str(row.chat_guid)
-                const identifierRaw = row.chat_identifier == null ? '' : str(row.chat_identifier)
-                const service = row.service_name == null ? '' : str(row.service_name)
-
-                // chatId rules:
-                // - Group chats: use chat.guid (stable routing key)
-                // - Direct chats (DM): prefer database chat_identifier if it already contains a semicolon; otherwise prefix with service_name
-                let chatId: string
-                if (isGroup || !identifierRaw) {
-                    chatId = guid
-                } else if (identifierRaw.includes(';')) {
-                    chatId = identifierRaw
-                } else if (service) {
-                    chatId = `${service};${identifierRaw}`
-                } else {
-                    // In rare cases service_name is missing, default to iMessage prefix for consistency
-                    chatId = `iMessage;${identifierRaw}`
-                }
+                const chatId = this.resolveChatId(
+                    isGroup,
+                    str(row.chat_guid),
+                    row.chat_identifier == null ? '' : str(row.chat_identifier),
+                    row.service_name == null ? '' : str(row.service_name)
+                )
 
                 const displayName = row.display_name == null ? null : str(row.display_name)
                 const lastDateRaw = row.last_date
@@ -515,21 +517,13 @@ export class IMessageDatabase {
         // Parse reaction information
         const reaction = this.mapReactionType(row.associated_message_type)
 
-        // Use same chatId logic as listChats: groups use chat.guid, DMs use chat_identifier
         const isGroup = bool(row.is_group_chat)
-        const chatGuid = str(row.chat_guid)
-        const chatIdentifier = str(row.chat_id)
-        const chatService = row.chat_service == null ? '' : str(row.chat_service)
-        let resolvedChatId: string
-        if (isGroup || !chatIdentifier) {
-            resolvedChatId = chatGuid || chatIdentifier
-        } else if (chatIdentifier.includes(';')) {
-            resolvedChatId = chatIdentifier
-        } else if (chatService) {
-            resolvedChatId = `${chatService};${chatIdentifier}`
-        } else {
-            resolvedChatId = `iMessage;${chatIdentifier}`
-        }
+        const resolvedChatId = this.resolveChatId(
+            isGroup,
+            str(row.chat_guid),
+            str(row.chat_id),
+            row.chat_service == null ? '' : str(row.chat_service)
+        )
 
         return {
             id: str(row.id),

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -156,6 +156,8 @@ export class IMessageDatabase {
             handle.id as sender,
             handle.ROWID as sender_rowid,
             chat.chat_identifier as chat_id,
+            chat.guid as chat_guid,
+            chat.service_name as chat_service,
             chat.display_name as chat_name,
             chat.ROWID as chat_rowid,
             (SELECT COUNT(*) FROM chat_handle_join WHERE chat_handle_join.chat_id = chat.ROWID) > 1 as is_group_chat
@@ -513,14 +515,30 @@ export class IMessageDatabase {
         // Parse reaction information
         const reaction = this.mapReactionType(row.associated_message_type)
 
+        // Use same chatId logic as listChats: groups use chat.guid, DMs use chat_identifier
+        const isGroup = bool(row.is_group_chat)
+        const chatGuid = str(row.chat_guid)
+        const chatIdentifier = str(row.chat_id)
+        const chatService = row.chat_service == null ? '' : str(row.chat_service)
+        let resolvedChatId: string
+        if (isGroup || !chatIdentifier) {
+            resolvedChatId = chatGuid || chatIdentifier
+        } else if (chatIdentifier.includes(';')) {
+            resolvedChatId = chatIdentifier
+        } else if (chatService) {
+            resolvedChatId = `${chatService};${chatIdentifier}`
+        } else {
+            resolvedChatId = `iMessage;${chatIdentifier}`
+        }
+
         return {
             id: str(row.id),
             guid: str(row.guid),
             text: messageText,
             sender: str(row.sender, 'Unknown'),
             senderName: null,
-            chatId: str(row.chat_id),
-            isGroupChat: bool(row.is_group_chat),
+            chatId: resolvedChatId,
+            isGroupChat: isGroup,
             service: this.mapService(row.service),
             isRead: bool(row.is_read),
             isFromMe: bool(row.is_from_me),
@@ -600,6 +618,35 @@ export class IMessageDatabase {
     private convertMacTimestamp(timestamp: unknown): Date {
         if (!timestamp || typeof timestamp !== 'number') return new Date()
         return new Date(this.MAC_EPOCH + timestamp / 1000000)
+    }
+
+    /**
+     * Discover the local Messages.app guid prefix for group chats by inspecting one row.
+     * Returns the prefix that should be prepended to raw GUIDs for AppleScript `chat id`.
+     * Defaults to `any;+;` (modern macOS) if no group chats exist.
+     */
+    async discoverGroupChatPrefix(): Promise<string> {
+        await this.ensureInit()
+        try {
+            const row = this.db.prepare('SELECT guid, chat_identifier FROM chat WHERE style = 43 LIMIT 1').get() as
+                | { guid: string; chat_identifier: string }
+                | undefined
+            if (!row) return 'any;+;'
+            const guid = str(row.guid)
+            const identifier = str(row.chat_identifier)
+            // guid is e.g. "any;+;534ce85d..." and identifier is "534ce85d..."
+            const idx = guid.indexOf(identifier)
+            if (idx > 0) return guid.substring(0, idx)
+            // identifier might have extra prefix (e.g., "chat534ce85d...")
+            if (identifier.startsWith('chat') && guid.includes(identifier.substring(4))) {
+                const rawGuid = identifier.substring(4)
+                const rawIdx = guid.indexOf(rawGuid)
+                if (rawIdx > 0) return guid.substring(0, rawIdx)
+            }
+            return 'any;+;'
+        } catch {
+            return 'any;+;'
+        }
     }
 
     /**

--- a/src/core/sdk.ts
+++ b/src/core/sdk.ts
@@ -112,6 +112,21 @@ export class IMessageSDK {
             }
         }
 
+        // Discover the local group chat guid prefix (async, non-blocking)
+        this.database
+            .discoverGroupChatPrefix()
+            .then((prefix) => {
+                if ('setGroupChatPrefix' in this.sender && typeof this.sender.setGroupChatPrefix === 'function') {
+                    this.sender.setGroupChatPrefix(prefix)
+                }
+                if (this.config.debug) {
+                    console.log(`[SDK] Discovered group chat prefix: "${prefix}"`)
+                }
+            })
+            .catch(() => {
+                // Non-fatal: falls back to default "any;+;"
+            })
+
         if (this.config.debug) {
             console.log('[SDK] Initialization complete')
         }
@@ -514,7 +529,8 @@ export class IMessageSDK {
             events,
             this.pluginManager,
             this.config.debug,
-            this.outgoingManager
+            this.outgoingManager,
+            events?.initialLookbackMs
         )
 
         try {

--- a/src/core/sender.ts
+++ b/src/core/sender.ts
@@ -19,7 +19,7 @@ import {
     generateSendWithAttachmentScript,
     generateSendWithAttachmentToChat,
 } from '../utils/applescript'
-import { delay, validateChatId, validateMessageContent } from '../utils/common'
+import { buildGroupChatGuid, delay, validateChatId, validateMessageContent } from '../utils/common'
 import { convertToCompatibleFormat, downloadImage } from '../utils/download'
 import { Semaphore } from '../utils/semaphore'
 import { IMessageError, SendError } from './errors'
@@ -73,6 +73,8 @@ export class MessageSender {
     private readonly scriptTimeout: number
     /** Outgoing message manager */
     private outgoingManager: OutgoingMessageManager | null = null
+    /** Discovered group chat guid prefix for AppleScript (e.g., "any;+;") */
+    private groupChatPrefix = 'any;+;'
 
     constructor(debug = false, retryConfig?: Required<RetryConfig>, maxConcurrent = 5, scriptTimeout = 30000) {
         this.debug = debug
@@ -80,6 +82,13 @@ export class MessageSender {
         this.retryDelay = retryConfig?.delay ?? 1500
         this.semaphore = maxConcurrent > 0 ? new Semaphore(maxConcurrent) : null
         this.scriptTimeout = scriptTimeout
+    }
+
+    /**
+     * Set the group chat guid prefix discovered from the local Messages database.
+     */
+    setGroupChatPrefix(prefix: string): void {
+        this.groupChatPrefix = prefix
     }
 
     /**
@@ -359,32 +368,32 @@ export class MessageSender {
         hasText: boolean,
         resolvedPaths: string[]
     ): Promise<void> {
-        if (hasText && resolvedPaths.length > 0) {
-            // Strategy 1: Text + Attachments
-            const firstAttachment = resolvedPaths[0]!
-            const { script } = generateSendWithAttachmentToChat(groupId, text!, firstAttachment)
-            await this.executeWithRetry(script, `Send text and attachment to group ${groupId}`)
+        const normalizedId = buildGroupChatGuid(groupId, this.groupChatPrefix)
 
-            // Send remaining attachments
+        if (hasText && resolvedPaths.length > 0) {
+            const firstAttachment = resolvedPaths[0]!
+            const { script } = generateSendWithAttachmentToChat(normalizedId, text!, firstAttachment)
+            await this.executeWithRetry(script, `Send text and attachment to group ${normalizedId}`)
+
             for (let i = 1; i < resolvedPaths.length; i++) {
-                const { script: attachScript } = generateSendAttachmentToChat(groupId, resolvedPaths[i]!, this.debug)
+                const { script: attachScript } = generateSendAttachmentToChat(
+                    normalizedId,
+                    resolvedPaths[i]!,
+                    this.debug
+                )
                 await this.executeWithRetry(attachScript, `Send attachment ${i + 1}/${resolvedPaths.length}`)
-                // Extra delay between attachments
                 if (i < resolvedPaths.length - 1) {
                     await delay(500)
                 }
             }
         } else if (hasText) {
-            // Strategy 2: Text only
-            const script = generateSendTextToChat(groupId, text!)
-            await this.executeWithRetry(script, `Send text to group ${groupId}`)
+            const script = generateSendTextToChat(normalizedId, text!)
+            await this.executeWithRetry(script, `Send text to group ${normalizedId}`)
         } else {
-            // Strategy 3: Attachments only
             for (let i = 0; i < resolvedPaths.length; i++) {
-                const { script } = generateSendAttachmentToChat(groupId, resolvedPaths[i]!, this.debug)
-                const description = `Send attachment ${i + 1}/${resolvedPaths.length} to group ${groupId}`
+                const { script } = generateSendAttachmentToChat(normalizedId, resolvedPaths[i]!, this.debug)
+                const description = `Send attachment ${i + 1}/${resolvedPaths.length} to group ${normalizedId}`
                 await this.executeWithRetry(script, description)
-                // Extra delay between attachments to ensure previous one is sent
                 if (i < resolvedPaths.length - 1) {
                     await delay(500)
                 }

--- a/src/core/watcher.ts
+++ b/src/core/watcher.ts
@@ -22,6 +22,11 @@ export interface WatcherEvents {
     onGroupMessage?: MessageCallback
     /** Triggered when error occurs */
     onError?: (error: Error) => void
+    /** How far back (ms) to look for messages when the watcher first starts. Defaults to 10 000. */
+    initialLookbackMs?: number
+    /** Called after each successful poll with the current checkpoint time. Persist this externally
+     *  and pass it back as `initialLookbackMs` on restart to avoid missing messages. */
+    onCheckpoint?: (lastCheckTime: Date) => void
 }
 
 /**
@@ -117,6 +122,7 @@ export class MessageWatcher {
             })
 
             this.lastCheckTime = checkStart
+            this.events.onCheckpoint?.(checkStart)
 
             /** Filter out new messages */
             let newMessages = messages.filter((msg) => !this.seenMessageIds.has(msg.id))

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -136,15 +136,25 @@ export function validateChatId(chatId: string): void {
 /**
  * Build a full Messages.app guid for a group chat using the discovered prefix.
  * Strips any existing prefixes and reconstructs with the local format.
+ * Defensively avoids duplicating GUID segments if the prefix already overlaps.
  * @param rawChatId Chat identifier in any format
  * @param discoveredPrefix The prefix discovered from chat.db at init (e.g., "any;+;" or "iMessage;+;chat")
  */
 export function buildGroupChatGuid(rawChatId: string, discoveredPrefix: string): string {
+    // Extract the bare GUID (no service prefix, no "chat" prefix)
     let guid = rawChatId
     if (guid.includes(';')) {
         const parts = guid.split(';')
         guid = parts[parts.length - 1] ?? guid
     }
     if (guid.startsWith('chat')) guid = guid.substring(4)
-    return `${discoveredPrefix}${guid}`
+
+    // If the result already matches what we'd produce, return rawChatId as-is
+    const expected = `${discoveredPrefix}${guid}`
+    if (rawChatId === expected) return rawChatId
+
+    // Guard against a malformed prefix that already contains the GUID
+    if (discoveredPrefix.endsWith(guid)) return discoveredPrefix
+
+    return expected
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -32,78 +32,60 @@ export function validateMessageContent(
 }
 
 /**
- * Normalize chatId format
- * - Extracts GUID from AppleScript group format (e.g., `iMessage;+;chat...` -> `chat...`)
- * - Returns normalized chatId for consistent handling
- * @param chatId Chat identifier (may be in various formats)
- * @returns Normalized chatId
+ * Normalize chatId format by extracting the core identifier.
+ * - Group: `any;+;534ce85d...` -> `534ce85d...`
+ * - Legacy group: `iMessage;+;chat534ce85d...` -> `chat534ce85d...`
+ * - DM: `any;-;+1234567890` -> `+1234567890`
+ * - Already bare: returned as-is
  */
 export function normalizeChatId(chatId: string): string {
-    // AppleScript group format: iMessage;+;chat...
-    // Extract GUID part (chat...) for normalization
     if (chatId.includes(';')) {
         const parts = chatId.split(';')
-        // Check if it matches AppleScript group format: iMessage;+;chat...
-        if (parts.length >= 3 && parts[0] === 'iMessage' && parts[1] === '+' && parts[2]?.startsWith('chat')) {
-            // Extract GUID part (everything after the second semicolon)
-            return parts.slice(2).join(';')
-        }
+        return parts[parts.length - 1] ?? chatId
     }
     return chatId
 }
 
 /**
- * Check if a chatId represents a group chat (not a DM)
- *
- * @param chatId The chat identifier to check
- * @returns true if it's a group chat, false if it's a DM
+ * Check if a chatId represents a group chat (not a DM).
+ * Recognizes:
+ * - Modern macOS: `any;+;{guid}` or any `service;+;identifier`
+ * - Legacy: `iMessage;+;chat{guid}`
+ * - Bare GUID: `chat{guid}` (no semicolons, starts with "chat")
  */
 export function isGroupChatId(chatId: string): boolean {
-    // AppleScript group format: iMessage;+;chat...
-    if (chatId.startsWith('iMessage;+;chat')) {
-        return true
-    }
-
-    // Pure GUID format (no semicolon, starts with 'chat')
-    if (!chatId.includes(';') && chatId.startsWith('chat') && chatId.length > 10) {
-        return true
-    }
-
+    if (chatId.includes(';+;')) return true
+    if (chatId.startsWith('iMessage;+;chat')) return true
+    if (!chatId.includes(';') && chatId.startsWith('chat') && chatId.length > 10) return true
     return false
 }
 
 /**
- * Extract recipient from a service-prefixed chatId
- *
- * @param chatId The chat identifier (e.g., 'iMessage;+1234567890')
- * @returns The recipient part (e.g., '+1234567890'), or null if not a DM format
+ * Extract recipient from a service-prefixed DM chatId.
+ * Handles:
+ * - 3-part modern: `any;-;+1234567890` -> `+1234567890`
+ * - 2-part legacy: `iMessage;+1234567890` -> `+1234567890`
  */
 export function extractRecipientFromChatId(chatId: string): string | null {
-    if (!chatId.includes(';')) {
-        return null
-    }
+    if (!chatId.includes(';')) return null
+    if (isGroupChatId(chatId)) return null
 
-    // Skip group chat formats
-    if (isGroupChatId(chatId)) {
-        return null
-    }
-
-    // Extract recipient from service-prefixed format: service;recipient
     const parts = chatId.split(';')
-    if (parts.length === 2) {
-        return parts[1] || null
-    }
-
+    // 3-part DM: service;-;address (e.g., any;-;+1234567890)
+    if (parts.length === 3 && parts[1] === '-') return parts[2] || null
+    // 2-part DM: service;address (e.g., iMessage;+1234567890)
+    if (parts.length === 2) return parts[1] || null
     return null
 }
 
 /**
- * Validate chatId format
- * - Must be a non-empty string
- * - Three accepted forms:
- *   1) Group chats: GUID-like string without semicolon (e.g., `chat...`)
- *   2) Group chats (AppleScript): `iMessage;+;chat...` format
- *   3) DMs: service-prefixed identifier with semicolon (e.g., `iMessage;+1234567890`)
+ * Validate chatId format.
+ * Accepted forms:
+ *   1) Group: `service;+;guid` (e.g., `any;+;534ce85d...`)
+ *   2) Legacy group: `iMessage;+;chat{guid}`
+ *   3) Bare group GUID: `chat{guid}` or raw hex GUID (length >= 8)
+ *   4) DM: `service;-;address` (e.g., `any;-;+1234567890`)
+ *   5) Legacy DM: `service;address` (e.g., `iMessage;+1234567890`)
  * @throws Error when chatId is invalid
  */
 export function validateChatId(chatId: string): void {
@@ -111,12 +93,11 @@ export function validateChatId(chatId: string): void {
         throw new Error('chatId must be a non-empty string')
     }
 
-    // Check for AppleScript group format: iMessage;+;chat...
     if (chatId.includes(';')) {
         const parts = chatId.split(';')
-        // AppleScript group format: iMessage;+;chat...
-        if (parts.length >= 3 && parts[0] === 'iMessage' && parts[1] === '+' && parts[2]?.startsWith('chat')) {
-            // Validate GUID part length
+
+        // Group format: service;+;guid (e.g., any;+;534ce85d...)
+        if (parts.length >= 3 && parts[1] === '+') {
             const guidPart = parts.slice(2).join(';')
             if (guidPart.length < 8) {
                 throw new Error('Invalid chatId format: GUID too short')
@@ -124,18 +105,46 @@ export function validateChatId(chatId: string): void {
             return
         }
 
-        // DM format: <service>;<address>
-        const service = parts[0] || ''
-        const address = parts[1] || ''
-        const allowedServices = new Set(['iMessage', 'SMS', 'RCS'])
-        if (!allowedServices.has(service) || !address) {
-            throw new Error('Invalid chatId format: expected "<service>;<address>" or group GUID')
+        // DM format: service;-;address (e.g., any;-;+1234567890)
+        if (parts.length === 3 && parts[1] === '-') {
+            if (!parts[2]) {
+                throw new Error('Invalid chatId format: missing address')
+            }
+            return
         }
-        return
+
+        // Legacy DM format: service;address (e.g., iMessage;+1234567890)
+        if (parts.length === 2) {
+            const service = parts[0] || ''
+            const address = parts[1] || ''
+            const allowedServices = new Set(['iMessage', 'SMS', 'RCS', 'any'])
+            if (!allowedServices.has(service) || !address) {
+                throw new Error('Invalid chatId format: expected "<service>;<address>" or group GUID')
+            }
+            return
+        }
+
+        throw new Error('Invalid chatId format: unrecognized semicolon pattern')
     }
 
-    // No semicolon: treat as GUID-like; ensure non-trivial length
+    // No semicolons: bare GUID or chat-prefixed GUID
     if (chatId.length < 8) {
         throw new Error('Invalid chatId format: GUID too short')
     }
+}
+
+/**
+ * Build a full Messages.app guid for a group chat using the discovered prefix.
+ * Strips any existing prefixes and reconstructs with the local format.
+ * @param rawChatId Chat identifier in any format
+ * @param discoveredPrefix The prefix discovered from chat.db at init (e.g., "any;+;" or "iMessage;+;chat")
+ */
+export function buildGroupChatGuid(rawChatId: string, discoveredPrefix: string): string {
+    let guid = rawChatId
+    if (guid.includes(';')) {
+        const parts = guid.split(';')
+        guid = parts[parts.length - 1] ?? guid
+    }
+    if (guid.startsWith('chat')) guid = guid.substring(4)
+    return `${discoveredPrefix}${guid}`
 }


### PR DESCRIPTION
## Summary

On modern macOS (Sequoia 15+ / Tahoe 26), Messages.app uses `any;+;{guid}` for group chat IDs and `any;-;{phone}` for DMs in the `chat.guid` column. The existing code hardcodes `iMessage;+;chat{guid}` which does not exist in modern `chat.db`, causing all group chat sends to fail with AppleScript error -1728.

**Verified on macOS Tahoe 26.3.1:**
```
sqlite3 ~/Library/Messages/chat.db "SELECT chat_identifier, guid FROM chat WHERE style = 43 LIMIT 3;"
534ce85d...|any;+;534ce85d...
3e77c030...|any;+;3e77c030...
```

```applescript
-- Works:
tell application "Messages"
    set targetChat to chat id "any;+;534ce85d174c4709b8e84075f9078b04"
    send "hello" to targetChat
end tell

-- Fails (-1728):
tell application "Messages"
    set targetChat to chat id "iMessage;+;chat534ce85d174c4709b8e84075f9078b04"
    send "hello" to targetChat
end tell
```

## Changes

### Chat ID format recognition (`src/utils/common.ts`)
- **`isGroupChatId`**: now recognizes `any;+;{guid}` via `;+;` check (backward compatible with `iMessage;+;chat` and bare `chat{guid}`)
- **`validateChatId`**: accepts `service;+;guid` groups, `service;-;address` DMs, added `any` to allowed services
- **`extractRecipientFromChatId`**: handles 3-part `any;-;+phone` DM format (was only 2-part `iMessage;+phone`)
- **`normalizeChatId`**: updated to extract last part after `;` (was dead code -- exported but never imported)
- **`buildGroupChatGuid`** (new): strips any existing prefix and reconstructs with the discovered local prefix

### Startup format discovery (`src/core/database.ts`)
- **`discoverGroupChatPrefix()`** (new): queries one group chat from `chat.db` at SDK init to discover the local guid prefix format. Defaults to `any;+;` if no groups exist. This ensures backward compatibility -- on older macOS with `iMessage;+;chat` format, it discovers that prefix instead.

### Consistent chatId between getMessages and listChats (`src/core/database.ts`)
- `getMessages` now includes `chat.guid` and `chat.service_name` in the query
- `rowToMessage` uses `chat.guid` for group chats (same logic as `listChats`), fixing the inconsistency where `msg.chatId` and `chatInfo.chatId` differed for the same group

### Send normalization (`src/core/sender.ts`)
- `sendToGroupChat` normalizes `groupId` via `buildGroupChatGuid(groupId, discoveredPrefix)` before passing to AppleScript generators
- Added `setGroupChatPrefix()` setter, called by SDK after discovery

### SDK wiring (`src/core/sdk.ts`)
- Calls `database.discoverGroupChatPrefix()` async at init
- Passes discovered prefix to sender via `setGroupChatPrefix()`

### Watcher checkpoint (`src/core/watcher.ts`)
- Added `onCheckpoint` callback to `WatcherEvents`, called after each successful poll with `lastCheckTime`
- Consumers can persist this externally and pass it back as `initialLookbackMs` on restart to avoid missing messages

## Breaking Changes

**None.** All changes are backward-compatible extensions:
- `isGroupChatId` still recognizes old formats
- `validateChatId` still accepts old formats
- `discoverGroupChatPrefix` falls back to `any;+;` (modern default)
- `onCheckpoint` is optional
- `buildGroupChatGuid` is additive

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx biome check` passes
- [x] `npm run build` succeeds
- [x] Verified group send works via direct osascript on macOS Tahoe 26.3.1
- [ ] Needs testing on older macOS (Sonoma/Ventura) to confirm backward compat

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic discovery and configurable handling of group chat identifier prefixes.
  * Configurable initial message lookback on startup and checkpoint notifications for polling progress.

* **Bug Fixes**
  * Improved chat ID normalization and validation for more reliable group and DM handling.
  * More robust group-message sending using normalized group identifiers.

* **Tests**
  * Expanded tests covering additional chat ID formats and normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->