### PR TITLE
fix 🐛: use chat.guid for AppleScript routing instead of chat_identifier

### DIFF
--- a/__tests__/02-utils.test.ts
+++ b/__tests__/02-utils.test.ts
@@ -135,18 +135,28 @@ describe('Common Utils', () => {
             expect(() => validateChatId('chat45e2b868ce1e43da89af262922733382')).not.toThrow()
         })
 
-        it('should accept DM format', async () => {
+        it('should accept legacy DM format', async () => {
             const { validateChatId } = await import('../src/utils/common')
 
             expect(() => validateChatId('iMessage;+1234567890')).not.toThrow()
             expect(() => validateChatId('SMS;+1234567890')).not.toThrow()
             expect(() => validateChatId('iMessage;user@example.com')).not.toThrow()
+            expect(() => validateChatId('any;+1234567890')).not.toThrow()
         })
 
-        it('should accept AppleScript group format', async () => {
+        it('should accept 3-part DM format (macOS Tahoe)', async () => {
+            const { validateChatId } = await import('../src/utils/common')
+
+            expect(() => validateChatId('any;-;+1234567890')).not.toThrow()
+            expect(() => validateChatId('any;-;user@example.com')).not.toThrow()
+            expect(() => validateChatId('iMessage;-;+1234567890')).not.toThrow()
+        })
+
+        it('should accept group format (legacy and Tahoe)', async () => {
             const { validateChatId } = await import('../src/utils/common')
 
             expect(() => validateChatId('iMessage;+;chat61321855167474084')).not.toThrow()
+            expect(() => validateChatId('any;+;chat687179757169191512')).not.toThrow()
             expect(() => validateChatId('iMessage;+;chat45e2b868ce1e43da89af262922733382')).not.toThrow()
         })
 
@@ -158,24 +168,67 @@ describe('Common Utils', () => {
             expect(() => validateChatId('iMessage;+;chat123')).toThrow('Invalid chatId format: GUID too short')
             expect(() => validateChatId('InvalidService;+1234567890')).toThrow('Invalid chatId format')
             expect(() => validateChatId('iMessage;')).toThrow('Invalid chatId format')
+            expect(() => validateChatId('any;-;')).toThrow('Invalid chatId format: missing address')
+            expect(() => validateChatId('a;b;c')).toThrow('Invalid chatId format: unrecognized semicolon pattern')
         })
     })
 
     describe('normalizeChatId', () => {
-        it('should normalize AppleScript group format to GUID', async () => {
+        it('should strip service prefix from group chatIds', async () => {
             const { normalizeChatId } = await import('../src/utils/common')
 
             expect(normalizeChatId('iMessage;+;chat61321855167474084')).toBe('chat61321855167474084')
-            expect(normalizeChatId('iMessage;+;chat45e2b868ce1e43da89af262922733382')).toBe(
-                'chat45e2b868ce1e43da89af262922733382'
-            )
+            expect(normalizeChatId('any;+;chat687179757169191512')).toBe('chat687179757169191512')
         })
 
-        it('should return unchanged for other formats', async () => {
+        it('should return unchanged for non-group formats', async () => {
             const { normalizeChatId } = await import('../src/utils/common')
 
             expect(normalizeChatId('chat61321855167474084')).toBe('chat61321855167474084')
             expect(normalizeChatId('iMessage;+1234567890')).toBe('iMessage;+1234567890')
+            expect(normalizeChatId('any;-;+1234567890')).toBe('any;-;+1234567890')
+        })
+    })
+
+    describe('isGroupChatId', () => {
+        it('should detect group formats', async () => {
+            const { isGroupChatId } = await import('../src/utils/common')
+
+            expect(isGroupChatId('iMessage;+;chat61321855167474084')).toBe(true)
+            expect(isGroupChatId('any;+;chat687179757169191512')).toBe(true)
+            expect(isGroupChatId('chat493787071395575843')).toBe(true)
+        })
+
+        it('should reject non-group formats', async () => {
+            const { isGroupChatId } = await import('../src/utils/common')
+
+            expect(isGroupChatId('any;-;+1234567890')).toBe(false)
+            expect(isGroupChatId('iMessage;+1234567890')).toBe(false)
+            expect(isGroupChatId('+1234567890')).toBe(false)
+        })
+    })
+
+    describe('extractRecipientFromChatId', () => {
+        it('should extract from 3-part DM format', async () => {
+            const { extractRecipientFromChatId } = await import('../src/utils/common')
+
+            expect(extractRecipientFromChatId('any;-;+1234567890')).toBe('+1234567890')
+            expect(extractRecipientFromChatId('iMessage;-;user@example.com')).toBe('user@example.com')
+        })
+
+        it('should extract from legacy 2-part DM format', async () => {
+            const { extractRecipientFromChatId } = await import('../src/utils/common')
+
+            expect(extractRecipientFromChatId('iMessage;+1234567890')).toBe('+1234567890')
+            expect(extractRecipientFromChatId('SMS;+1234567890')).toBe('+1234567890')
+        })
+
+        it('should return null for group and bare formats', async () => {
+            const { extractRecipientFromChatId } = await import('../src/utils/common')
+
+            expect(extractRecipientFromChatId('any;+;chat687179757169191512')).toBeNull()
+            expect(extractRecipientFromChatId('chat61321855167474084')).toBeNull()
+            expect(extractRecipientFromChatId('+1234567890')).toBeNull()
         })
     })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,9 +92,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -112,9 +109,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -132,9 +126,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [
@@ -152,9 +143,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT OR Apache-2.0",
             "optional": true,
             "os": [

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -26,6 +26,26 @@ const str = (v: unknown, fallback = ''): string => (v == null ? fallback : Strin
 const num = (v: unknown, fallback = 0): number => (typeof v === 'number' ? v : fallback)
 const bool = (v: unknown): boolean => Boolean(v)
 
+// resolveChatId returns the chat identifier used for AppleScript routing.
+// Prefers chat.guid which already carries the service prefix
+// (e.g. "iMessage;+;chat613...") that AppleScript's "chat id" requires.
+function resolveChatId(
+    guid: string,
+    identifier: string,
+    serviceName: string
+): string {
+    if (guid) {
+        return guid
+    }
+    if (identifier.includes(';')) {
+        return identifier
+    }
+    if (serviceName) {
+        return `${serviceName};${identifier}`
+    }
+    return `iMessage;${identifier}`
+}
+
 /**
  * Runtime detection and database adapter
  * Automatically uses bun:sqlite for Bun runtime, better-sqlite3 for Node.js
@@ -156,6 +176,8 @@ export class IMessageDatabase {
             handle.id as sender,
             handle.ROWID as sender_rowid,
             chat.chat_identifier as chat_id,
+            chat.guid as chat_guid,
+            chat.service_name as chat_service,
             chat.display_name as chat_name,
             chat.ROWID as chat_rowid,
             (SELECT COUNT(*) FROM chat_handle_join WHERE chat_handle_join.chat_id = chat.ROWID) > 1 as is_group_chat
@@ -354,20 +376,7 @@ export class IMessageDatabase {
                 const identifierRaw = row.chat_identifier == null ? '' : str(row.chat_identifier)
                 const service = row.service_name == null ? '' : str(row.service_name)
 
-                // chatId rules:
-                // - Group chats: use chat.guid (stable routing key)
-                // - Direct chats (DM): prefer database chat_identifier if it already contains a semicolon; otherwise prefix with service_name
-                let chatId: string
-                if (isGroup || !identifierRaw) {
-                    chatId = guid
-                } else if (identifierRaw.includes(';')) {
-                    chatId = identifierRaw
-                } else if (service) {
-                    chatId = `${service};${identifierRaw}`
-                } else {
-                    // In rare cases service_name is missing, default to iMessage prefix for consistency
-                    chatId = `iMessage;${identifierRaw}`
-                }
+                const chatId = resolveChatId(guid, identifierRaw, service)
 
                 const displayName = row.display_name == null ? null : str(row.display_name)
                 const lastDateRaw = row.last_date
@@ -513,13 +522,19 @@ export class IMessageDatabase {
         // Parse reaction information
         const reaction = this.mapReactionType(row.associated_message_type)
 
+        const chatId = resolveChatId(
+            str(row.chat_guid),
+            str(row.chat_id),
+            str(row.chat_service)
+        )
+
         return {
             id: str(row.id),
             guid: str(row.guid),
             text: messageText,
             sender: str(row.sender, 'Unknown'),
             senderName: null,
-            chatId: str(row.chat_id),
+            chatId,
             isGroupChat: bool(row.is_group_chat),
             service: this.mapService(row.service),
             isRead: bool(row.is_read),

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -29,11 +29,7 @@ const bool = (v: unknown): boolean => Boolean(v)
 // resolveChatId returns the chat identifier used for AppleScript routing.
 // Prefers chat.guid which already carries the service prefix
 // (e.g. "iMessage;+;chat613...") that AppleScript's "chat id" requires.
-function resolveChatId(
-    guid: string,
-    identifier: string,
-    serviceName: string
-): string {
+function resolveChatId(guid: string, identifier: string, serviceName: string): string {
     if (guid) {
         return guid
     }
@@ -522,11 +518,7 @@ export class IMessageDatabase {
         // Parse reaction information
         const reaction = this.mapReactionType(row.associated_message_type)
 
-        const chatId = resolveChatId(
-            str(row.chat_guid),
-            str(row.chat_id),
-            str(row.chat_service)
-        )
+        const chatId = resolveChatId(str(row.chat_guid), str(row.chat_id), str(row.chat_service))
 
         return {
             id: str(row.id),

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -33,6 +33,9 @@ function resolveChatId(guid: string, identifier: string, serviceName: string): s
     if (guid) {
         return guid
     }
+    if (!identifier) {
+        return ''
+    }
     if (identifier.includes(';')) {
         return identifier
     }
@@ -200,8 +203,8 @@ export class IMessageDatabase {
         }
 
         if (chatId) {
-            query += ' AND chat.chat_identifier = ?'
-            params.push(chatId)
+            query += ' AND (chat.chat_identifier = ? OR chat.guid = ?)'
+            params.push(chatId, chatId)
         }
 
         if (service) {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -32,20 +32,14 @@ export function validateMessageContent(
 }
 
 /**
- * Normalize chatId format
- * - Extracts GUID from AppleScript group format (e.g., `iMessage;+;chat...` -> `chat...`)
- * - Returns normalized chatId for consistent handling
- * @param chatId Chat identifier (may be in various formats)
- * @returns Normalized chatId
+ * normalizeChatId strips the service prefix from group chatIds.
+ *   "any;+;chat687..." → "chat687..."
+ * Non-group IDs are returned as-is.
  */
 export function normalizeChatId(chatId: string): string {
-    // AppleScript group format: iMessage;+;chat...
-    // Extract GUID part (chat...) for normalization
     if (chatId.includes(';')) {
         const parts = chatId.split(';')
-        // Check if it matches AppleScript group format: iMessage;+;chat...
-        if (parts.length >= 3 && parts[0] === 'iMessage' && parts[1] === '+' && parts[2]?.startsWith('chat')) {
-            // Extract GUID part (everything after the second semicolon)
+        if (parts.length >= 3 && parts[1] === '+') {
             return parts.slice(2).join(';')
         }
     }
@@ -59,24 +53,19 @@ export function normalizeChatId(chatId: string): string {
  * @returns true if it's a group chat, false if it's a DM
  */
 export function isGroupChatId(chatId: string): boolean {
-    // AppleScript group format: iMessage;+;chat...
-    if (chatId.startsWith('iMessage;+;chat')) {
-        return true
-    }
+    if (chatId.includes(';+;')) return true
 
     // Pure GUID format (no semicolon, starts with 'chat')
-    if (!chatId.includes(';') && chatId.startsWith('chat') && chatId.length > 10) {
-        return true
-    }
+    if (!chatId.includes(';') && chatId.startsWith('chat') && chatId.length > 10) return true
 
     return false
 }
 
 /**
- * Extract recipient from a service-prefixed chatId
+ * Extract recipient from a DM chatId
  *
- * @param chatId The chat identifier (e.g., 'iMessage;+1234567890')
- * @returns The recipient part (e.g., '+1234567890'), or null if not a DM format
+ * @param chatId e.g., `any;-;+1234567890` or `iMessage;+1234567890`
+ * @returns The address part (e.g., `+1234567890`), or null if group/unknown format
  */
 export function extractRecipientFromChatId(chatId: string): string | null {
     if (!chatId.includes(';')) {
@@ -88,35 +77,35 @@ export function extractRecipientFromChatId(chatId: string): string | null {
         return null
     }
 
-    // Extract recipient from service-prefixed format: service;recipient
     const parts = chatId.split(';')
-    if (parts.length === 2) {
-        return parts[1] || null
-    }
+    // 3-part DM: service;-;address (e.g., any;-;+1234567890)
+    if (parts.length === 3 && parts[1] === '-') return parts[2] || null
+    // 2-part legacy DM: service;address (e.g., iMessage;+1234567890)
+    if (parts.length === 2) return parts[1] || null
 
     return null
 }
 
 /**
  * Validate chatId format
- * - Must be a non-empty string
- * - Three accepted forms:
- *   1) Group chats: GUID-like string without semicolon (e.g., `chat...`)
- *   2) Group chats (AppleScript): `iMessage;+;chat...` format
- *   3) DMs: service-prefixed identifier with semicolon (e.g., `iMessage;+1234567890`)
  * @throws Error when chatId is invalid
+ *
+ * Accepted forms:
+ *   1) Group: `service;+;guid` (e.g., `any;+;chat687...`, `iMessage;+;chat613...`)
+ *   2) DM: `service;-;address` (e.g., `any;-;+1234567890`)
+ *   3) Legacy DM: `service;address` (e.g., `iMessage;+1234567890`)
+ *   4) Bare GUID: `chat{id}` or raw hex (length >= 8, no semicolons)
  */
 export function validateChatId(chatId: string): void {
     if (!chatId || typeof chatId !== 'string') {
         throw new Error('chatId must be a non-empty string')
     }
 
-    // Check for AppleScript group format: iMessage;+;chat...
     if (chatId.includes(';')) {
         const parts = chatId.split(';')
-        // AppleScript group format: iMessage;+;chat...
-        if (parts.length >= 3 && parts[0] === 'iMessage' && parts[1] === '+' && parts[2]?.startsWith('chat')) {
-            // Validate GUID part length
+
+        // service;+;guid
+        if (parts.length >= 3 && parts[1] === '+') {
             const guidPart = parts.slice(2).join(';')
             if (guidPart.length < 8) {
                 throw new Error('Invalid chatId format: GUID too short')
@@ -124,14 +113,26 @@ export function validateChatId(chatId: string): void {
             return
         }
 
-        // DM format: <service>;<address>
-        const service = parts[0] || ''
-        const address = parts[1] || ''
-        const allowedServices = new Set(['iMessage', 'SMS', 'RCS'])
-        if (!allowedServices.has(service) || !address) {
-            throw new Error('Invalid chatId format: expected "<service>;<address>" or group GUID')
+        // service;-;address
+        if (parts.length === 3 && parts[1] === '-') {
+            if (!parts[2]) {
+                throw new Error('Invalid chatId format: missing address')
+            }
+            return
         }
-        return
+
+        // service;address (legacy)
+        if (parts.length === 2) {
+            const service = parts[0] || ''
+            const address = parts[1] || ''
+            const allowedServices = new Set(['iMessage', 'SMS', 'RCS', 'any'])
+            if (!allowedServices.has(service) || !address) {
+                throw new Error('Invalid chatId format: expected "<service>;<address>" or group GUID')
+            }
+            return
+        }
+
+        throw new Error('Invalid chatId format: unrecognized semicolon pattern')
     }
 
     // No semicolon: treat as GUID-like; ensure non-trivial length


### PR DESCRIPTION
## Summary

  - **`getMessages()`** returned `chat.chat_identifier` (e.g. `chat687...`) as `chatId` — AppleScript's `chat id` command requires the full `chat.guid`
  (e.g. `iMessage;+;chat613...`). This broke group chat replies on all macOS versions.
  - **`listChats()`** had a separate 13-line if/else to construct chatId; replaced with shared `resolveChatId()`.
  - **Format helpers** (`isGroupChatId`, `normalizeChatId`, `extractRecipientFromChatId`, `validateChatId`) were hardcoded to `iMessage;+;` — now support
  macOS Tahoe's `any;+;` / `any;-;` format.

  ## `chat.guid` format by macOS version

  Verified against real `chat.db` on three machines:

  | macOS | Type | `chat.guid` | `service_name` |
  |---|---|---|---|
  | 15.7 Sequoia | Group (iMessage) | `iMessage;+;chat61321855167474084` | `iMessage` |
  | 15.7 Sequoia | DM (iMessage) | `iMessage;-;+14155798594` | `iMessage` |
  | 15.7 Sequoia | DM (SMS) | `SMS;-;+12134155486` | `SMS` |
  | 26.1 Tahoe | Group | `any;+;chat687179757169191512` | `any` |
  | 26.1 Tahoe | DM | `any;-;+13322593374` | `any` |
  | 26.2 Tahoe | DM | `any;-;+14157918488` | `any` |

  **Key change in Tahoe:** `service_name` and guid prefix become `any` for all services (iMessage, SMS, RCS). The `;+;` (group) and `;-;` (DM) separators
  remain unchanged.

  ## What changed

  | File | Change |
  |---|---|
  | `src/core/database.ts` | Add `chat.guid` / `chat.service_name` to SQL; new `resolveChatId()` used by both `getMessages()` and `listChats()` |
  | `src/utils/common.ts` | Remove hardcoded `iMessage` prefix checks; support `any;+;`, `any;-;` formats; add `service;-;address` DM parsing |

  ## Test plan

  - [x] 46 related tests pass (utils, message-promise, service-routing)
  - [x] Full suite: 207/214 pass (7 pre-existing failures, 0 new)
  - [ ] Manual: send to group chat on macOS 15
  - [ ] Manual: send to group chat on macOS 26

  ## Acknowledgments

  Thanks to [@Artitus](https://github.com/Artitus) for identifying the macOS Tahoe `any;+;` format change in #43.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized chat ID derivation so messages and chat listings use a single, consistent resolver.
  * Broadened parsing and validation to accept multiple chat ID formats (group and several DM variants) with clearer error handling.

* **Tests**
  * Expanded and renamed tests to cover legacy and new formats, normalization, group detection, recipient extraction, and explicit error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->