### PR TITLE
fix 🐛: ensure TempFileManager.destroy() cleans temp files

### DIFF
--- a/__tests__/17-temp-file-manager.test.ts
+++ b/__tests__/17-temp-file-manager.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+describe('TempFileManager destroy flow', () => {
+    it('should clean temp files before marking the manager destroyed', () => {
+        const source = readFileSync(new URL('../src/utils/temp-file-manager.ts', import.meta.url), 'utf-8')
+
+        const destroyStart = source.indexOf('async destroy(): Promise<void> {')
+        const stopIndex = source.indexOf('this.stop()', destroyStart)
+        const cleanupIndex = source.indexOf('await this.cleanupAll()', destroyStart)
+        const destroyedIndex = source.indexOf('this.isDestroyed = true', destroyStart)
+
+        expect(destroyStart).toBeGreaterThanOrEqual(0)
+        expect(stopIndex).toBeGreaterThan(destroyStart)
+        expect(cleanupIndex).toBeGreaterThan(stopIndex)
+        expect(destroyedIndex).toBeGreaterThan(cleanupIndex)
+    })
+})

--- a/__tests__/17-temp-file-manager.test.ts
+++ b/__tests__/17-temp-file-manager.test.ts
@@ -1,44 +1,50 @@
 import { describe, expect, it } from 'bun:test'
-import { readFileSync } from 'node:fs'
 import { TempFileManager } from '../src/utils/temp-file-manager'
 
 describe('TempFileManager destroy flow', () => {
-    it('should clean temp files before marking the manager destroyed', () => {
-        const source = readFileSync(new URL('../src/utils/temp-file-manager.ts', import.meta.url), 'utf-8')
+    it('should keep the manager active until cleanup finishes', async () => {
+        const manager = new TempFileManager()
+        let destroyedDuringCleanup: boolean | null = null
+        let destroyingDuringCleanup: boolean | null = null
 
-        const destroyMatch = source.match(/async\s+destroy\s*\(\s*\)\s*:\s*Promise<void>\s*\{/)
-        const destroyStart = destroyMatch?.index ?? -1
-
-        expect(destroyStart).toBeGreaterThanOrEqual(0)
-
-        const bodyStart = source.indexOf('{', destroyStart)
-        expect(bodyStart).toBeGreaterThanOrEqual(0)
-
-        let depth = 0
-        let destroyEnd = -1
-        for (let i = bodyStart; i < source.length; i++) {
-            const char = source[i]
-            if (char === '{') {
-                depth++
-            } else if (char === '}') {
-                depth--
-                if (depth === 0) {
-                    destroyEnd = i
-                    break
-                }
+        ;(
+            manager as TempFileManager & {
+                cleanupAll: () => Promise<{ removed: number; errors: number }>
+                isDestroyed: boolean
+                isDestroying: boolean
             }
+        ).cleanupAll = async () => {
+            destroyedDuringCleanup = (
+                manager as TempFileManager & {
+                    isDestroyed: boolean
+                }
+            ).isDestroyed
+            destroyingDuringCleanup = (
+                manager as TempFileManager & {
+                    isDestroying: boolean
+                }
+            ).isDestroying
+            return { removed: 0, errors: 0 }
         }
 
-        expect(destroyEnd).toBeGreaterThan(bodyStart)
+        await manager.destroy()
 
-        const destroySource = source.slice(bodyStart, destroyEnd)
-        const stopIndex = destroySource.indexOf('this.stop()')
-        const cleanupIndex = destroySource.indexOf('await this.cleanupAll()')
-        const destroyedIndex = destroySource.lastIndexOf('this.isDestroyed = true')
-
-        expect(stopIndex).toBeGreaterThanOrEqual(0)
-        expect(cleanupIndex).toBeGreaterThan(stopIndex)
-        expect(destroyedIndex).toBeGreaterThan(cleanupIndex)
+        expect(destroyedDuringCleanup).toBe(false)
+        expect(destroyingDuringCleanup).toBe(true)
+        expect(
+            (
+                manager as TempFileManager & {
+                    isDestroyed: boolean
+                }
+            ).isDestroyed
+        ).toBe(true)
+        expect(
+            (
+                manager as TempFileManager & {
+                    isDestroying: boolean
+                }
+            ).isDestroying
+        ).toBe(false)
     })
 
     it('should block start and reuse the same destroy operation while cleanup is in progress', async () => {
@@ -62,7 +68,7 @@ describe('TempFileManager destroy flow', () => {
         const destroy2 = manager.destroy()
 
         expect(cleanupCalls).toBe(1)
-        expect(() => manager.start()).toThrow('TempFileManager is destroyed, cannot start')
+        expect(() => manager.start()).toThrow('TempFileManager is destroying, cannot start')
         expect(resolveCleanup).not.toBeNull()
 
         resolveCleanup?.()

--- a/__tests__/17-temp-file-manager.test.ts
+++ b/__tests__/17-temp-file-manager.test.ts
@@ -1,18 +1,73 @@
 import { describe, expect, it } from 'bun:test'
 import { readFileSync } from 'node:fs'
+import { TempFileManager } from '../src/utils/temp-file-manager'
 
 describe('TempFileManager destroy flow', () => {
     it('should clean temp files before marking the manager destroyed', () => {
         const source = readFileSync(new URL('../src/utils/temp-file-manager.ts', import.meta.url), 'utf-8')
 
-        const destroyStart = source.indexOf('async destroy(): Promise<void> {')
-        const stopIndex = source.indexOf('this.stop()', destroyStart)
-        const cleanupIndex = source.indexOf('await this.cleanupAll()', destroyStart)
-        const destroyedIndex = source.indexOf('this.isDestroyed = true', destroyStart)
+        const destroyMatch = source.match(/async\s+destroy\s*\(\s*\)\s*:\s*Promise<void>\s*\{/)
+        const destroyStart = destroyMatch?.index ?? -1
 
         expect(destroyStart).toBeGreaterThanOrEqual(0)
-        expect(stopIndex).toBeGreaterThan(destroyStart)
+
+        const bodyStart = source.indexOf('{', destroyStart)
+        expect(bodyStart).toBeGreaterThanOrEqual(0)
+
+        let depth = 0
+        let destroyEnd = -1
+        for (let i = bodyStart; i < source.length; i++) {
+            const char = source[i]
+            if (char === '{') {
+                depth++
+            } else if (char === '}') {
+                depth--
+                if (depth === 0) {
+                    destroyEnd = i
+                    break
+                }
+            }
+        }
+
+        expect(destroyEnd).toBeGreaterThan(bodyStart)
+
+        const destroySource = source.slice(bodyStart, destroyEnd)
+        const stopIndex = destroySource.indexOf('this.stop()')
+        const cleanupIndex = destroySource.indexOf('await this.cleanupAll()')
+        const destroyedIndex = destroySource.lastIndexOf('this.isDestroyed = true')
+
+        expect(stopIndex).toBeGreaterThanOrEqual(0)
         expect(cleanupIndex).toBeGreaterThan(stopIndex)
         expect(destroyedIndex).toBeGreaterThan(cleanupIndex)
+    })
+
+    it('should block start and reuse the same destroy operation while cleanup is in progress', async () => {
+        const manager = new TempFileManager()
+        let cleanupCalls = 0
+        let resolveCleanup: (() => void) | null = null
+
+        ;(
+            manager as TempFileManager & {
+                cleanupAll: () => Promise<{ removed: number; errors: number }>
+            }
+        ).cleanupAll = async () => {
+            cleanupCalls++
+            await new Promise<void>((resolve) => {
+                resolveCleanup = resolve
+            })
+            return { removed: 0, errors: 0 }
+        }
+
+        const destroy1 = manager.destroy()
+        const destroy2 = manager.destroy()
+
+        expect(cleanupCalls).toBe(1)
+        expect(() => manager.start()).toThrow('TempFileManager is destroyed, cannot start')
+        expect(resolveCleanup).not.toBeNull()
+
+        resolveCleanup?.()
+        await Promise.all([destroy1, destroy2])
+
+        expect(() => manager.start()).toThrow('TempFileManager is destroyed, cannot start')
     })
 })

--- a/src/utils/temp-file-manager.ts
+++ b/src/utils/temp-file-manager.ts
@@ -54,7 +54,11 @@ export class TempFileManager {
      * Start cleanup task
      */
     start(): void {
-        if (this.isDestroyed || this.isDestroying) {
+        if (this.isDestroying) {
+            throw new Error('TempFileManager is destroying, cannot start')
+        }
+
+        if (this.isDestroyed) {
             throw new Error('TempFileManager is destroyed, cannot start')
         }
 
@@ -162,7 +166,7 @@ export class TempFileManager {
      * Called when SDK is destroyed, immediately clean all imsg_temp_* files
      */
     async cleanupAll(): Promise<{ removed: number; errors: number }> {
-        if (this.isDestroyed && !this.isDestroying) {
+        if (this.isDestroyed) {
             return { removed: 0, errors: 0 }
         }
 

--- a/src/utils/temp-file-manager.ts
+++ b/src/utils/temp-file-manager.ts
@@ -38,6 +38,8 @@ export interface TempFileManagerConfig {
 export class TempFileManager {
     private readonly config: Required<TempFileManagerConfig>
     private cleanupTimer: NodeJS.Timeout | null = null
+    private destroyPromise: Promise<void> | null = null
+    private isDestroying = false
     private isDestroyed = false
 
     constructor(config: TempFileManagerConfig = {}) {
@@ -52,7 +54,7 @@ export class TempFileManager {
      * Start cleanup task
      */
     start(): void {
-        if (this.isDestroyed) {
+        if (this.isDestroyed || this.isDestroying) {
             throw new Error('TempFileManager is destroyed, cannot start')
         }
 
@@ -160,7 +162,7 @@ export class TempFileManager {
      * Called when SDK is destroyed, immediately clean all imsg_temp_* files
      */
     async cleanupAll(): Promise<{ removed: number; errors: number }> {
-        if (this.isDestroyed) {
+        if (this.isDestroyed && !this.isDestroying) {
             return { removed: 0, errors: 0 }
         }
 
@@ -234,15 +236,32 @@ export class TempFileManager {
             return
         }
 
-        this.stop()
+        if (this.destroyPromise) {
+            await this.destroyPromise
+            return
+        }
 
-        // Clean up all temp files
-        await this.cleanupAll()
+        this.destroyPromise = (async () => {
+            this.isDestroying = true
+            this.stop()
 
-        this.isDestroyed = true
+            try {
+                // Clean up all temp files
+                await this.cleanupAll()
+            } finally {
+                this.isDestroyed = true
+                this.isDestroying = false
 
-        if (this.config.debug) {
-            console.log('[TempFileManager] Destroyed')
+                if (this.config.debug) {
+                    console.log('[TempFileManager] Destroyed')
+                }
+            }
+        })()
+
+        try {
+            await this.destroyPromise
+        } finally {
+            this.destroyPromise = null
         }
     }
 

--- a/src/utils/temp-file-manager.ts
+++ b/src/utils/temp-file-manager.ts
@@ -234,11 +234,12 @@ export class TempFileManager {
             return
         }
 
-        this.isDestroyed = true
         this.stop()
 
         // Clean up all temp files
         await this.cleanupAll()
+
+        this.isDestroyed = true
 
         if (this.config.debug) {
             console.log('[TempFileManager] Destroyed')


### PR DESCRIPTION
`TempFileManager.destroy()` was setting `isDestroyed` before calling `cleanupAll()`. Since `cleanupAll()` exits early when the manager is already destroyed, shutdown cleanup could be skipped and `imsg_temp_*` files could be left behind.

This change reorders the destroy flow so cleanup runs first, then the manager is marked as destroyed.

Also adds a regression test to lock the expected destroy order.

Validation:
- `bun test`
- `npm run type-check`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary-file manager shutdown: cleanup now runs in the correct order, is serialized for concurrent shutdown requests, and prevents new starts while shutdown is in progress—reducing race conditions and duplicate cleanup.

* **Tests**
  * Added tests verifying shutdown ordering, that concurrent shutdown calls only perform cleanup once, and that start operations are blocked appropriately during and after shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->