### PR TITLE
fix: v3.0.0-rc.2 — remove darwin os restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@photon-ai/imessage-kit",
-    "version": "3.0.0-rc.1",
+    "version": "3.0.0-rc.2",
     "description": "Type-safe macOS iMessage SDK for TypeScript",
     "author": "GreatSomething",
     "license": "MIT",
@@ -71,6 +71,5 @@
     "engines": {
         "node": ">=20.0.0"
     },
-    "os": ["darwin"],
     "sideEffects": false
 }


### PR DESCRIPTION
## Summary
- Remove `"os": ["darwin"]` from package.json so the package can be installed on Linux CI runners
- The package is pure TS; native dep `better-sqlite3` is already in `optionalDependencies`
- Version bump to `3.0.0-rc.2`

## Test plan
- [x] `npm run build` passes
- [x] `tsc --noEmit` passes
- [x] All 405 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 3.0.0-rc.2
  * Expanded platform support—package is now available for installation and use across additional operating systems beyond previous restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->