### PR TITLE
Release v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@photon-ai/imessage-kit",
-    "version": "3.0.0-rc.3",
+    "version": "3.0.0",
     "description": "Type-safe macOS iMessage SDK for TypeScript",
     "author": "GreatSomething",
     "license": "MIT",


### PR DESCRIPTION
Bumps version from `3.0.0-rc.3` to `3.0.0`. Source tree is unchanged from rc.3 — diff is one line in `package.json`.

## ⚠️ Breaking — macOS version support

**v3 requires macOS 26 (Tahoe) or newer. macOS 15 and below are no longer supported.**

Rationale: the chat.db schema changed in macOS 26 (new attributedBody layout, revised `chat_message_join` timing, tahoe-only columns referenced by the query adapter). The single `macos26Queries` adapter in `src/infra/db/macos26.ts` is the only implementation; there is no fallback path for older schemas.

Users on macOS 15 or below should stay on the `2.x` line:

```bash
npm install @photon-ai/imessage-kit@^2
```

## Release trail

- `3.0.0-rc.1` — architecture rewrite
- `3.0.0-rc.2` — weekday scheduling, Tahoe search filter, db close ordering, gitattributes merge
- `3.0.0-rc.3` — error cause-chain preservation, watcher hardening, example/docs audit
- `3.0.0` — this PR (same tree as rc.3)

## Post-merge

After merge to main:
1. Tag `v3.0.0` on the merge commit
2. `npm publish --access public` (no `--tag`, moves `latest` from `2.1.2` → `3.0.0`)

## Verification

- [x] `bun test` — 348 pass / 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm pack --dry-run` — 9 files, 185.5kB
- [x] Diff = 1 line in `package.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Released stable version 3.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->