### PR TITLE
Revise advanced features note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@
 A full-featured iMessage SDK for **reading**, **sending**, and **automating** iMessage conversations on macOS. Perfect for building AI agents, automation tools, and chat-first applications.
 
 > [!NOTE]
-> **✨ Looking for advanced features like threaded replies, tapbacks, message editing, unsending, live typing indicators? Check out [Advanced iMessage Kit](https://github.com/photon-hq/advanced-imessage-kit) and contact us at daniel@photon.codes.**
+> ✨ Looking for advanced features like threaded replies, tapbacks, message editing, unsending, live typing indicators? Try **[Photon Spectrum](https://photon.codes)**
+
+## About Photon
+
+**[Photon](https://photon.codes)** builds infrastructure for AI agents that operate over real communication channels.
+
+Spectrum is Photon’s open-source multi-channel agent framework, enabling AI agents to communicate through interfaces people already use—such as iMessage, SMS, email, Slack, Discord, and voice—instead of being confined to web chat.
 
 ---
 


### PR DESCRIPTION
Updated the note about advanced features to promote Photon Spectrum instead of Advanced iMessage Kit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/imessage-kit/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783552675&installation_id=127326493&pr_number=53&repository=photon-hq%2Fimessage-kit&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fimessage-kit%2Fpull%2F53&signature=596410778b5ad3db3021f66a94ab3247c5d812e9bbf7cd329f7f5693be5cc585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated call-to-action to direct users to Photon Spectrum for advanced features.
  * Added contextual information about Photon to documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->